### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install linux dependencies
-        run: sudo apt-get install -y clang libssl-dev llvm libudev-dev protobuf-compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libssl-dev llvm libudev-dev protobuf-compiler
 
       - name: Install Rust
         run: |


### PR DESCRIPTION
My last (non-test) commit in #18 has caused [this error](https://github.com/zdave-parity/polkadot-bulletin-chain/actions/runs/6119209489/job/16886253705). Looks like we need to do `apt-get update` before `install`