### PR TITLE
Add bridge pallets + basic bridge configuration

### DIFF
--- a/BRIDGES.md
+++ b/BRIDGES.md
@@ -21,8 +21,14 @@ git remote add -f bridges https://github.com/paritytech/parity-bridges-common.gi
 git fetch bridges --prune
 git subtree pull --prefix=bridges bridges polkadot-v.1.0.0-audited --squash
 
+# if the command above fails with the "Can't squash-merge: 'bridges' was never added" or
+# "fatal: refusing to merge unrelated histories" error, use this:
+# git merge -s subtree -Xsubtree="bridges" bridges/polkadot-v.1.0.0-audited --allow-unrelated-histories --squash
+
 # so, after fetch and before solving conflicts just run patch,
 # this will remove unneeded files and checks if subtree modules compiles
+#
+# if it fails to build, you'll need to resolve conflicts manually
 ./bridges/scripts/verify-pallets-build.sh --ignore-git-state --no-revert
 
 # if there are conflicts, this could help,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,6 +688,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "bp-bridge-hub-cumulus"
+version = "0.1.0"
+dependencies = [
+ "bp-messages",
+ "bp-polkadot-core",
+ "bp-runtime",
+ "frame-support",
+ "frame-system",
+ "polkadot-primitives",
+ "sp-api",
+ "sp-std",
+]
+
+[[package]]
+name = "bp-bridge-hub-polkadot"
+version = "0.1.0"
+dependencies = [
+ "bp-bridge-hub-cumulus",
+ "bp-messages",
+ "bp-runtime",
+ "frame-support",
+ "sp-api",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "bp-header-chain"
 version = "0.1.0"
 dependencies = [
@@ -734,6 +761,35 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "bp-polkadot"
+version = "0.1.0"
+dependencies = [
+ "bp-header-chain",
+ "bp-polkadot-core",
+ "bp-runtime",
+ "frame-support",
+ "sp-api",
+ "sp-std",
+]
+
+[[package]]
+name = "bp-polkadot-bulletin"
+version = "0.1.0"
+dependencies = [
+ "bp-header-chain",
+ "bp-messages",
+ "bp-polkadot-core",
+ "bp-runtime",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
  "sp-runtime",
  "sp-std",
 ]
@@ -5563,6 +5619,16 @@ dependencies = [
 name = "polkadot-bulletin-chain-runtime"
 version = "0.1.0-dev"
 dependencies = [
+ "bp-bridge-hub-polkadot",
+ "bp-header-chain",
+ "bp-messages",
+ "bp-parachains",
+ "bp-polkadot",
+ "bp-polkadot-bulletin",
+ "bp-polkadot-core",
+ "bp-runtime",
+ "bp-test-utils",
+ "bridge-runtime-common",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",
@@ -5572,6 +5638,9 @@ dependencies = [
  "frame-try-runtime",
  "pallet-authorship",
  "pallet-babe",
+ "pallet-bridge-grandpa",
+ "pallet-bridge-messages",
+ "pallet-bridge-parachains",
  "pallet-grandpa",
  "pallet-im-online",
  "pallet-offences",
@@ -5588,14 +5657,19 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core",
  "sp-inherents",
+ "sp-io",
+ "sp-keyring",
  "sp-offchain",
  "sp-runtime",
  "sp-session",
  "sp-std",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
+ "sp-trie",
  "sp-version",
+ "static_assertions",
  "substrate-wasm-builder",
+ "xcm",
 ]
 
 [[package]]
@@ -5624,6 +5698,32 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "polkadot-primitives"
+version = "1.0.0"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v1.0.0#c9ec8c5a15959ce711bb60aa79add58f560d61e9"
+dependencies = [
+ "bitvec",
+ "hex-literal",
+ "parity-scale-codec",
+ "polkadot-core-primitives",
+ "polkadot-parachain",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-authority-discovery",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -7981,6 +8081,19 @@ dependencies = [
  "serde",
  "sp-std",
  "static_assertions",
+]
+
+[[package]]
+name = "sp-authority-discovery"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/bridges/bin/runtime-common/src/refund_relayer_extension.rs
+++ b/bridges/bin/runtime-common/src/refund_relayer_extension.rs
@@ -24,8 +24,8 @@ use crate::messages_call_ext::{
 };
 use bp_messages::{LaneId, MessageNonce};
 use bp_relayers::{RewardsAccountOwner, RewardsAccountParams};
-use bp_runtime::{Parachain, ParachainIdOf, RangeInclusiveExt, StaticStrProvider};
-use codec::{Decode, Encode};
+use bp_runtime::{Chain, Parachain, ParachainIdOf, RangeInclusiveExt, StaticStrProvider};
+use codec::{Codec, Decode, Encode};
 use frame_support::{
 	dispatch::{CallableCallFor, DispatchInfo, PostDispatchInfo},
 	traits::IsSubType,
@@ -33,7 +33,8 @@ use frame_support::{
 	CloneNoBound, DefaultNoBound, EqNoBound, PartialEqNoBound, RuntimeDebugNoBound,
 };
 use pallet_bridge_grandpa::{
-	CallSubType as GrandpaCallSubType, SubmitFinalityProofHelper, SubmitFinalityProofInfo,
+	CallSubType as GrandpaCallSubType, Config as GrandpaConfig, SubmitFinalityProofHelper,
+	SubmitFinalityProofInfo,
 };
 use pallet_bridge_messages::Config as MessagesConfig;
 use pallet_bridge_parachains::{
@@ -96,7 +97,7 @@ where
 /// coming from this lane.
 pub trait RefundableMessagesLaneId {
 	/// The instance of the bridge messages pallet.
-	type Instance;
+	type Instance: 'static;
 	/// The messages lane id.
 	type Id: Get<LaneId>;
 }
@@ -106,6 +107,7 @@ pub struct RefundableMessagesLane<Instance, Id>(PhantomData<(Instance, Id)>);
 
 impl<Instance, Id> RefundableMessagesLaneId for RefundableMessagesLane<Instance, Id>
 where
+	Instance: 'static,
 	Id: Get<LaneId>,
 {
 	type Instance = Instance;
@@ -165,7 +167,11 @@ pub enum CallInfo {
 		SubmitParachainHeadsInfo,
 		MessagesCallInfo,
 	),
+	/// Relay chain finality + message delivery/confirmation calls.
+	RelayFinalityAndMsgs(SubmitFinalityProofInfo<RelayBlockNumber>, MessagesCallInfo),
 	/// Parachain finality + message delivery/confirmation calls.
+	///
+	/// This variant is used only when bridging with parachain.
 	ParachainFinalityAndMsgs(SubmitParachainHeadsInfo, MessagesCallInfo),
 	/// Standalone message delivery/confirmation call.
 	Msgs(MessagesCallInfo),
@@ -184,6 +190,7 @@ impl CallInfo {
 	fn submit_finality_proof_info(&self) -> Option<SubmitFinalityProofInfo<RelayBlockNumber>> {
 		match *self {
 			Self::AllFinalityAndMsgs(info, _, _) => Some(info),
+			Self::RelayFinalityAndMsgs(info, _) => Some(info),
 			_ => None,
 		}
 	}
@@ -201,6 +208,7 @@ impl CallInfo {
 	fn messages_call_info(&self) -> &MessagesCallInfo {
 		match self {
 			Self::AllFinalityAndMsgs(_, _, info) => info,
+			Self::RelayFinalityAndMsgs(_, info) => info,
 			Self::ParachainFinalityAndMsgs(_, info) => info,
 			Self::Msgs(info) => info,
 		}
@@ -209,13 +217,369 @@ impl CallInfo {
 
 /// The actions on relayer account that need to be performed because of his actions.
 #[derive(RuntimeDebug, PartialEq)]
-enum RelayerAccountAction<AccountId, Reward> {
+pub enum RelayerAccountAction<AccountId, Reward> {
 	/// Do nothing with relayer account.
 	None,
 	/// Reward the relayer.
 	Reward(AccountId, RewardsAccountParams, Reward),
 	/// Slash the relayer.
 	Slash(AccountId, RewardsAccountParams),
+}
+
+/// Everything common among our refund signed extensions.
+pub trait RefundSignedExtension:
+	'static + Clone + Codec + sp_std::fmt::Debug + Default + Eq + PartialEq + Send + Sync + TypeInfo
+where
+	<Self::Runtime as GrandpaConfig<Self::GrandpaInstance>>::BridgedChain:
+		Chain<BlockNumber = RelayBlockNumber>,
+{
+	/// This chain runtime.
+	type Runtime: UtilityConfig<RuntimeCall = CallOf<Self::Runtime>>
+		+ GrandpaConfig<Self::GrandpaInstance>
+		+ MessagesConfig<<Self::Msgs as RefundableMessagesLaneId>::Instance>
+		+ RelayersConfig;
+	/// Grandpa pallet reference.
+	type GrandpaInstance: 'static;
+	/// Messages pallet and lane reference.
+	type Msgs: RefundableMessagesLaneId;
+	/// Refund amount calculator.
+	type Refund: RefundCalculator<Balance = <Self::Runtime as RelayersConfig>::Reward>;
+	/// Priority boost calculator.
+	type Priority: Get<TransactionPriority>;
+	/// Signed extension unique identifier.
+	type Id: StaticStrProvider;
+
+	/// Unpack batch runtime call.
+	fn expand_call(call: &CallOf<Self::Runtime>) -> Vec<&CallOf<Self::Runtime>>;
+
+	/// Given runtime call, check if it has supported format. Additionally, check if any of
+	/// (optionally batched) calls are obsolete and we shall reject the transaction.
+	fn parse_and_check_for_obsolete_call(
+		call: &CallOf<Self::Runtime>,
+	) -> Result<Option<CallInfo>, TransactionValidityError>;
+
+	/// Check if parsed call is already obsolete.
+	fn check_obsolete_parsed_call(
+		call: &CallOf<Self::Runtime>,
+	) -> Result<&CallOf<Self::Runtime>, TransactionValidityError>;
+
+	/// Called from post-dispatch and shall perform additional checks (apart from relay
+	/// chain finality and messages transaction finality) of given call result.
+	fn additional_call_result_check(
+		relayer: &AccountIdOf<Self::Runtime>,
+		call_info: &CallInfo,
+	) -> bool;
+
+	/// Given post-dispatch information, analyze the outcome of relayer call and return
+	/// actions that need to be performed on relayer account.
+	fn analyze_call_result(
+		pre: Option<Option<PreDispatchData<AccountIdOf<Self::Runtime>>>>,
+		info: &DispatchInfo,
+		post_info: &PostDispatchInfo,
+		len: usize,
+		result: &DispatchResult,
+	) -> RelayerAccountAction<AccountIdOf<Self::Runtime>, <Self::Runtime as RelayersConfig>::Reward>
+	{
+		let mut extra_weight = Weight::zero();
+		let mut extra_size = 0;
+
+		// We don't refund anything for transactions that we don't support.
+		let (relayer, call_info) = match pre {
+			Some(Some(pre)) => (pre.relayer, pre.call_info),
+			_ => return RelayerAccountAction::None,
+		};
+
+		// now we know that the relayer either needs to be rewarded, or slashed
+		// => let's prepare the correspondent account that pays reward/receives slashed amount
+		let reward_account_params =
+			RewardsAccountParams::new(
+				<Self::Msgs as RefundableMessagesLaneId>::Id::get(),
+				<Self::Runtime as MessagesConfig<
+					<Self::Msgs as RefundableMessagesLaneId>::Instance,
+				>>::BridgedChainId::get(),
+				if call_info.is_receive_messages_proof_call() {
+					RewardsAccountOwner::ThisChain
+				} else {
+					RewardsAccountOwner::BridgedChain
+				},
+			);
+
+		// prepare return value for the case if the call has failed or it has not caused
+		// expected side effects (e.g. not all messages have been accepted)
+		//
+		// we are not checking if relayer is registered here - it happens during the slash attempt
+		//
+		// there are couple of edge cases here:
+		//
+		// - when the relayer becomes registered during message dispatch: this is unlikely + relayer
+		//   should be ready for slashing after registration;
+		//
+		// - when relayer is registered after `validate` is called and priority is not boosted:
+		//   relayer should be ready for slashing after registration.
+		let may_slash_relayer =
+			Self::bundled_messages_for_priority_boost(Some(&call_info)).is_some();
+		let slash_relayer_if_delivery_result = may_slash_relayer
+			.then(|| RelayerAccountAction::Slash(relayer.clone(), reward_account_params))
+			.unwrap_or(RelayerAccountAction::None);
+
+		// We don't refund anything if the transaction has failed.
+		if let Err(e) = result {
+			log::trace!(
+				target: "runtime::bridge",
+				"{} via {:?}: relayer {:?} has submitted invalid messages transaction: {:?}",
+				Self::Id::STR,
+				<Self::Msgs as RefundableMessagesLaneId>::Id::get(),
+				relayer,
+				e,
+			);
+			return slash_relayer_if_delivery_result
+		}
+
+		// check if relay chain state has been updated
+		if let Some(finality_proof_info) = call_info.submit_finality_proof_info() {
+			if !SubmitFinalityProofHelper::<Self::Runtime, Self::GrandpaInstance>::was_successful(
+				finality_proof_info.block_number,
+			) {
+				// we only refund relayer if all calls have updated chain state
+				log::trace!(
+					target: "runtime::bridge",
+					"{} via {:?}: relayer {:?} has submitted invalid relay chain finality proof",
+					Self::Id::STR,
+					<Self::Msgs as RefundableMessagesLaneId>::Id::get(),
+					relayer,
+				);
+				return slash_relayer_if_delivery_result
+			}
+
+			// there's a conflict between how bridge GRANDPA pallet works and a `utility.batchAll`
+			// transaction. If relay chain header is mandatory, the GRANDPA pallet returns
+			// `Pays::No`, because such transaction is mandatory for operating the bridge. But
+			// `utility.batchAll` transaction always requires payment. But in both cases we'll
+			// refund relayer - either explicitly here, or using `Pays::No` if he's choosing
+			// to submit dedicated transaction.
+
+			// submitter has means to include extra weight/bytes in the `submit_finality_proof`
+			// call, so let's subtract extra weight/size to avoid refunding for this extra stuff
+			extra_weight = finality_proof_info.extra_weight;
+			extra_size = finality_proof_info.extra_size;
+		}
+
+		// Check if the `ReceiveMessagesProof` call delivered at least some of the messages that
+		// it contained. If this happens, we consider the transaction "helpful" and refund it.
+		let msgs_call_info = call_info.messages_call_info();
+		if !MessagesCallHelper::<Self::Runtime, <Self::Msgs as RefundableMessagesLaneId>::Instance>::was_successful(msgs_call_info) {
+			log::trace!(
+				target: "runtime::bridge",
+				"{} via {:?}: relayer {:?} has submitted invalid messages call",
+				Self::Id::STR,
+				<Self::Msgs as RefundableMessagesLaneId>::Id::get(),
+				relayer,
+			);
+			return slash_relayer_if_delivery_result
+		}
+
+		// do additional check
+		if !Self::additional_call_result_check(&relayer, &call_info) {
+			return slash_relayer_if_delivery_result
+		}
+
+		// regarding the tip - refund that happens here (at this side of the bridge) isn't the whole
+		// relayer compensation. He'll receive some amount at the other side of the bridge. It shall
+		// (in theory) cover the tip there. Otherwise, if we'll be compensating tip here, some
+		// malicious relayer may use huge tips, effectively depleting account that pay rewards. The
+		// cost of this attack is nothing. Hence we use zero as tip here.
+		let tip = Zero::zero();
+
+		// decrease post-dispatch weight/size using extra weight/size that we know now
+		let post_info_len = len.saturating_sub(extra_size as usize);
+		let mut post_info_weight =
+			post_info.actual_weight.unwrap_or(info.weight).saturating_sub(extra_weight);
+
+		// let's also replace the weight of slashing relayer with the weight of rewarding relayer
+		if call_info.is_receive_messages_proof_call() {
+			post_info_weight = post_info_weight.saturating_sub(
+				<Self::Runtime as RelayersConfig>::WeightInfo::extra_weight_of_successful_receive_messages_proof_call(),
+			);
+		}
+
+		// compute the relayer refund
+		let mut post_info = *post_info;
+		post_info.actual_weight = Some(post_info_weight);
+		let refund = Self::Refund::compute_refund(info, &post_info, post_info_len, tip);
+
+		// we can finally reward relayer
+		RelayerAccountAction::Reward(relayer, reward_account_params, refund)
+	}
+
+	/// Returns number of bundled messages `Some(_)`, if the given call info is a:
+	///
+	/// - message delivery transaction;
+	///
+	/// - with reasonable bundled messages that may be accepted by the messages pallet.
+	///
+	/// This function is used to check whether the transaction priority should be
+	/// virtually boosted. The relayer registration (we only boost priority for registered
+	/// relayer transactions) must be checked outside.
+	fn bundled_messages_for_priority_boost(call_info: Option<&CallInfo>) -> Option<MessageNonce> {
+		// we only boost priority of message delivery transactions
+		let parsed_call = match call_info {
+			Some(parsed_call) if parsed_call.is_receive_messages_proof_call() => parsed_call,
+			_ => return None,
+		};
+
+		// compute total number of messages in transaction
+		let bundled_messages = parsed_call.messages_call_info().bundled_messages().saturating_len();
+
+		// a quick check to avoid invalid high-priority transactions
+		let max_unconfirmed_messages_in_confirmation_tx = <Self::Runtime as MessagesConfig<
+			<Self::Msgs as RefundableMessagesLaneId>::Instance,
+		>>::MaxUnconfirmedMessagesAtInboundLane::get(
+		);
+		if bundled_messages > max_unconfirmed_messages_in_confirmation_tx {
+			return None
+		}
+
+		Some(bundled_messages)
+	}
+}
+
+/// Adapter that allow implementing `sp_runtime::traits::SignedExtension` for any
+/// `RefundSignedExtension`.
+#[derive(
+	DefaultNoBound,
+	CloneNoBound,
+	Decode,
+	Encode,
+	EqNoBound,
+	PartialEqNoBound,
+	RuntimeDebugNoBound,
+	TypeInfo,
+)]
+pub struct RefundSignedExtensionAdapter<T: RefundSignedExtension>(T)
+where
+	<T::Runtime as GrandpaConfig<T::GrandpaInstance>>::BridgedChain:
+		Chain<BlockNumber = RelayBlockNumber>;
+
+impl<T: RefundSignedExtension> SignedExtension for RefundSignedExtensionAdapter<T>
+where
+	<T::Runtime as GrandpaConfig<T::GrandpaInstance>>::BridgedChain:
+		Chain<BlockNumber = RelayBlockNumber>,
+	CallOf<T::Runtime>: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>
+		+ IsSubType<CallableCallFor<UtilityPallet<T::Runtime>, T::Runtime>>
+		+ GrandpaCallSubType<T::Runtime, T::GrandpaInstance>
+		+ MessagesCallSubType<T::Runtime, <T::Msgs as RefundableMessagesLaneId>::Instance>,
+{
+	const IDENTIFIER: &'static str = T::Id::STR;
+	type AccountId = AccountIdOf<T::Runtime>;
+	type Call = CallOf<T::Runtime>;
+	type AdditionalSigned = ();
+	type Pre = Option<PreDispatchData<AccountIdOf<T::Runtime>>>;
+
+	fn additional_signed(&self) -> Result<(), TransactionValidityError> {
+		Ok(())
+	}
+
+	fn validate(
+		&self,
+		who: &Self::AccountId,
+		call: &Self::Call,
+		_info: &DispatchInfoOf<Self::Call>,
+		_len: usize,
+	) -> TransactionValidity {
+		// this is the only relevant line of code for the `pre_dispatch`
+		//
+		// we're not calling `validate` from `pre_dispatch` directly because of performance
+		// reasons, so if you're adding some code that may fail here, please check if it needs
+		// to be added to the `pre_dispatch` as well
+		let parsed_call = T::parse_and_check_for_obsolete_call(call)?;
+
+		// the following code just plays with transaction priority and never returns an error
+
+		// we only boost priority of presumably correct message delivery transactions
+		let bundled_messages = match T::bundled_messages_for_priority_boost(parsed_call.as_ref()) {
+			Some(bundled_messages) => bundled_messages,
+			None => return Ok(Default::default()),
+		};
+
+		// we only boost priority if relayer has staked required balance
+		if !RelayersPallet::<T::Runtime>::is_registration_active(who) {
+			return Ok(Default::default())
+		}
+
+		// compute priority boost
+		let priority_boost =
+			crate::priority_calculator::compute_priority_boost::<T::Priority>(bundled_messages);
+		let valid_transaction = ValidTransactionBuilder::default().priority(priority_boost);
+
+		log::trace!(
+			target: "runtime::bridge",
+			"{} via {:?} has boosted priority of message delivery transaction \
+			of relayer {:?}: {} messages -> {} priority",
+			Self::IDENTIFIER,
+			<T::Msgs as RefundableMessagesLaneId>::Id::get(),
+			who,
+			bundled_messages,
+			priority_boost,
+		);
+
+		valid_transaction.build()
+	}
+
+	fn pre_dispatch(
+		self,
+		who: &Self::AccountId,
+		call: &Self::Call,
+		_info: &DispatchInfoOf<Self::Call>,
+		_len: usize,
+	) -> Result<Self::Pre, TransactionValidityError> {
+		// this is a relevant piece of `validate` that we need here (in `pre_dispatch`)
+		let parsed_call = T::parse_and_check_for_obsolete_call(call)?;
+
+		Ok(parsed_call.map(|call_info| {
+			log::trace!(
+				target: "runtime::bridge",
+				"{} via {:?} parsed bridge transaction in pre-dispatch: {:?}",
+				Self::IDENTIFIER,
+				<T::Msgs as RefundableMessagesLaneId>::Id::get(),
+				call_info,
+			);
+			PreDispatchData { relayer: who.clone(), call_info }
+		}))
+	}
+
+	fn post_dispatch(
+		pre: Option<Self::Pre>,
+		info: &DispatchInfoOf<Self::Call>,
+		post_info: &PostDispatchInfoOf<Self::Call>,
+		len: usize,
+		result: &DispatchResult,
+	) -> Result<(), TransactionValidityError> {
+		let call_result = T::analyze_call_result(pre, info, post_info, len, result);
+
+		match call_result {
+			RelayerAccountAction::None => (),
+			RelayerAccountAction::Reward(relayer, reward_account, reward) => {
+				RelayersPallet::<T::Runtime>::register_relayer_reward(
+					reward_account,
+					&relayer,
+					reward,
+				);
+
+				log::trace!(
+					target: "runtime::bridge",
+					"{} via {:?} has registered reward: {:?} for {:?}",
+					Self::IDENTIFIER,
+					<T::Msgs as RefundableMessagesLaneId>::Id::get(),
+					reward,
+					relayer,
+				);
+			},
+			RelayerAccountAction::Slash(relayer, slash_account) =>
+				RelayersPallet::<T::Runtime>::slash_and_deregister(&relayer, slash_account),
+		}
+
+		Ok(())
+	}
 }
 
 /// Signed extension that refunds a relayer for new messages coming from a parachain.
@@ -259,8 +623,8 @@ pub struct RefundBridgedParachainMessages<Runtime, Para, Msgs, Refund, Priority,
 	)>,
 );
 
-impl<Runtime, Para, Msgs, Refund, Priority, Id>
-	RefundBridgedParachainMessages<Runtime, Para, Msgs, Refund, Priority, Id>
+impl<Runtime, Para, Msgs, Refund, Priority, Id> RefundSignedExtension
+	for RefundBridgedParachainMessages<Runtime, Para, Msgs, Refund, Priority, Id>
 where
 	Self: 'static + Send + Sync,
 	Runtime: UtilityConfig<RuntimeCall = CallOf<Runtime>>
@@ -279,7 +643,14 @@ where
 		+ ParachainsCallSubType<Runtime, Para::Instance>
 		+ MessagesCallSubType<Runtime, Msgs::Instance>,
 {
-	fn expand_call<'a>(&self, call: &'a CallOf<Runtime>) -> Vec<&'a CallOf<Runtime>> {
+	type Runtime = Runtime;
+	type GrandpaInstance = Runtime::BridgesGrandpaPalletInstance;
+	type Msgs = Msgs;
+	type Refund = Refund;
+	type Priority = Priority;
+	type Id = Id;
+
+	fn expand_call(call: &CallOf<Runtime>) -> Vec<&CallOf<Runtime>> {
 		match call.is_sub_type() {
 			Some(UtilityCall::<Runtime>::batch_all { ref calls }) if calls.len() <= 3 =>
 				calls.iter().collect(),
@@ -289,12 +660,11 @@ where
 	}
 
 	fn parse_and_check_for_obsolete_call(
-		&self,
 		call: &CallOf<Runtime>,
 	) -> Result<Option<CallInfo>, TransactionValidityError> {
-		let calls = self.expand_call(call);
+		let calls = Self::expand_call(call);
 		let total_calls = calls.len();
-		let mut calls = calls.into_iter().map(Self::check_obsolete_call).rev();
+		let mut calls = calls.into_iter().map(Self::check_obsolete_parsed_call).rev();
 
 		let msgs_call = calls.next().transpose()?.and_then(|c| c.call_info_for(Msgs::Id::get()));
 		let para_finality_call = calls
@@ -315,7 +685,7 @@ where
 		})
 	}
 
-	fn check_obsolete_call(
+	fn check_obsolete_parsed_call(
 		call: &CallOf<Runtime>,
 	) -> Result<&CallOf<Runtime>, TransactionValidityError> {
 		call.check_obsolete_submit_finality_proof()?;
@@ -324,98 +694,7 @@ where
 		Ok(call)
 	}
 
-	/// Given post-dispatch information, analyze the outcome of relayer call and return
-	/// actions that need to be performed on relayer account.
-	fn analyze_call_result(
-		pre: Option<Option<PreDispatchData<Runtime::AccountId>>>,
-		info: &DispatchInfo,
-		post_info: &PostDispatchInfo,
-		len: usize,
-		result: &DispatchResult,
-	) -> RelayerAccountAction<AccountIdOf<Runtime>, Runtime::Reward> {
-		let mut extra_weight = Weight::zero();
-		let mut extra_size = 0;
-
-		// We don't refund anything for transactions that we don't support.
-		let (relayer, call_info) = match pre {
-			Some(Some(pre)) => (pre.relayer, pre.call_info),
-			_ => return RelayerAccountAction::None,
-		};
-
-		// now we know that the relayer either needs to be rewarded, or slashed
-		// => let's prepare the correspondent account that pays reward/receives slashed amount
-		let reward_account_params = RewardsAccountParams::new(
-			Msgs::Id::get(),
-			Runtime::BridgedChainId::get(),
-			if call_info.is_receive_messages_proof_call() {
-				RewardsAccountOwner::ThisChain
-			} else {
-				RewardsAccountOwner::BridgedChain
-			},
-		);
-
-		// prepare return value for the case if the call has failed or it has not caused
-		// expected side effects (e.g. not all messages have been accepted)
-		//
-		// we are not checking if relayer is registered here - it happens during the slash attempt
-		//
-		// there are couple of edge cases here:
-		//
-		// - when the relayer becomes registered during message dispatch: this is unlikely + relayer
-		//   should be ready for slashing after registration;
-		//
-		// - when relayer is registered after `validate` is called and priority is not boosted:
-		//   relayer should be ready for slashing after registration.
-		let may_slash_relayer =
-			Self::bundled_messages_for_priority_boost(Some(&call_info)).is_some();
-		let slash_relayer_if_delivery_result = may_slash_relayer
-			.then(|| RelayerAccountAction::Slash(relayer.clone(), reward_account_params))
-			.unwrap_or(RelayerAccountAction::None);
-
-		// We don't refund anything if the transaction has failed.
-		if let Err(e) = result {
-			log::trace!(
-				target: "runtime::bridge",
-				"{} from parachain {} via {:?}: relayer {:?} has submitted invalid messages transaction: {:?}",
-				Self::IDENTIFIER,
-				Para::Id::get(),
-				Msgs::Id::get(),
-				relayer,
-				e,
-			);
-			return slash_relayer_if_delivery_result
-		}
-
-		// check if relay chain state has been updated
-		if let Some(finality_proof_info) = call_info.submit_finality_proof_info() {
-			if !SubmitFinalityProofHelper::<Runtime, Runtime::BridgesGrandpaPalletInstance>::was_successful(
-				finality_proof_info.block_number,
-			) {
-				// we only refund relayer if all calls have updated chain state
-				log::trace!(
-					target: "runtime::bridge",
-					"{} from parachain {} via {:?}: relayer {:?} has submitted invalid relay chain finality proof",
-					Self::IDENTIFIER,
-					Para::Id::get(),
-					Msgs::Id::get(),
-					relayer,
-				);
-				return slash_relayer_if_delivery_result;
-			}
-
-			// there's a conflict between how bridge GRANDPA pallet works and a `utility.batchAll`
-			// transaction. If relay chain header is mandatory, the GRANDPA pallet returns
-			// `Pays::No`, because such transaction is mandatory for operating the bridge. But
-			// `utility.batchAll` transaction always requires payment. But in both cases we'll
-			// refund relayer - either explicitly here, or using `Pays::No` if he's choosing
-			// to submit dedicated transaction.
-
-			// submitter has means to include extra weight/bytes in the `submit_finality_proof`
-			// call, so let's subtract extra weight/size to avoid refunding for this extra stuff
-			extra_weight = finality_proof_info.extra_weight;
-			extra_size = finality_proof_info.extra_size;
-		}
-
+	fn additional_call_result_check(relayer: &Runtime::AccountId, call_info: &CallInfo) -> bool {
 		// check if parachain state has been updated
 		if let Some(para_proof_info) = call_info.submit_parachain_heads_info() {
 			if !SubmitParachainHeadsHelper::<Runtime, Para::Instance>::was_successful(
@@ -425,220 +704,123 @@ where
 				log::trace!(
 					target: "runtime::bridge",
 					"{} from parachain {} via {:?}: relayer {:?} has submitted invalid parachain finality proof",
-					Self::IDENTIFIER,
+					Id::STR,
 					Para::Id::get(),
 					Msgs::Id::get(),
 					relayer,
 				);
-				return slash_relayer_if_delivery_result
+				return false
 			}
 		}
 
-		// Check if the `ReceiveMessagesProof` call delivered at least some of the messages that
-		// it contained. If this happens, we consider the transaction "helpful" and refund it.
-		let msgs_call_info = call_info.messages_call_info();
-		if !MessagesCallHelper::<Runtime, Msgs::Instance>::was_successful(msgs_call_info) {
-			log::trace!(
-				target: "runtime::bridge",
-				"{} from parachain {} via {:?}: relayer {:?} has submitted invalid messages call",
-				Self::IDENTIFIER,
-				Para::Id::get(),
-				Msgs::Id::get(),
-				relayer,
-			);
-			return slash_relayer_if_delivery_result
-		}
-
-		// regarding the tip - refund that happens here (at this side of the bridge) isn't the whole
-		// relayer compensation. He'll receive some amount at the other side of the bridge. It shall
-		// (in theory) cover the tip there. Otherwise, if we'll be compensating tip here, some
-		// malicious relayer may use huge tips, effectively depleting account that pay rewards. The
-		// cost of this attack is nothing. Hence we use zero as tip here.
-		let tip = Zero::zero();
-
-		// decrease post-dispatch weight/size using extra weight/size that we know now
-		let post_info_len = len.saturating_sub(extra_size as usize);
-		let mut post_info_weight =
-			post_info.actual_weight.unwrap_or(info.weight).saturating_sub(extra_weight);
-
-		// let's also replace the weight of slashing relayer with the weight of rewarding relayer
-		if call_info.is_receive_messages_proof_call() {
-			post_info_weight = post_info_weight.saturating_sub(
-				<Runtime as RelayersConfig>::WeightInfo::extra_weight_of_successful_receive_messages_proof_call(),
-			);
-		}
-
-		// compute the relayer refund
-		let mut post_info = *post_info;
-		post_info.actual_weight = Some(post_info_weight);
-		let refund = Refund::compute_refund(info, &post_info, post_info_len, tip);
-
-		// we can finally reward relayer
-		RelayerAccountAction::Reward(relayer, reward_account_params, refund)
-	}
-
-	/// Returns number of bundled messages `Some(_)`, if the given call info is a:
-	///
-	/// - message delivery transaction;
-	///
-	/// - with reasonable bundled messages that may be accepted by the messages pallet.
-	///
-	/// This function is used to check whether the transaction priority should be
-	/// virtually boosted. The relayer registration (we only boost priority for registered
-	/// relayer transactions) must be checked outside.
-	fn bundled_messages_for_priority_boost(call_info: Option<&CallInfo>) -> Option<MessageNonce> {
-		// we only boost priority of message delivery transactions
-		let parsed_call = match call_info {
-			Some(parsed_call) if parsed_call.is_receive_messages_proof_call() => parsed_call,
-			_ => return None,
-		};
-
-		// compute total number of messages in transaction
-		let bundled_messages = parsed_call.messages_call_info().bundled_messages().saturating_len();
-
-		// a quick check to avoid invalid high-priority transactions
-		if bundled_messages > Runtime::MaxUnconfirmedMessagesAtInboundLane::get() {
-			return None
-		}
-
-		Some(bundled_messages)
+		true
 	}
 }
 
-impl<Runtime, Para, Msgs, Refund, Priority, Id> SignedExtension
-	for RefundBridgedParachainMessages<Runtime, Para, Msgs, Refund, Priority, Id>
+/// Signed extension that refunds a relayer for new messages coming from a standalone (GRANDPA)
+/// chain.
+///
+/// Also refunds relayer for successful finality delivery if it comes in batch (`utility.batchAll`)
+/// with message delivery transaction. Batch may deliver either both relay chain header and
+/// parachain head, or just parachain head. Corresponding headers must be used in messages
+/// proof verification.
+///
+/// Extension does not refund transaction tip due to security reasons.
+#[derive(
+	DefaultNoBound,
+	CloneNoBound,
+	Decode,
+	Encode,
+	EqNoBound,
+	PartialEqNoBound,
+	RuntimeDebugNoBound,
+	TypeInfo,
+)]
+#[scale_info(skip_type_params(Runtime, GrandpaInstance, Msgs, Refund, Priority, Id))]
+pub struct RefundBridgedGrandpaMessages<Runtime, GrandpaInstance, Msgs, Refund, Priority, Id>(
+	PhantomData<(
+		// runtime with `frame-utility`, `pallet-bridge-grandpa`,
+		// `pallet-bridge-messages` and `pallet-bridge-relayers` pallets deployed
+		Runtime,
+		// bridge GRANDPA pallet instance, used to track bridged chain state
+		GrandpaInstance,
+		// implementation of `RefundableMessagesLaneId` trait, which specifies the instance of
+		// the used `pallet-bridge-messages` pallet and the lane within this pallet
+		Msgs,
+		// implementation of the `RefundCalculator` trait, that is used to compute refund that
+		// we give to relayer for his transaction
+		Refund,
+		// getter for per-message `TransactionPriority` boost that we give to message
+		// delivery transactions
+		Priority,
+		// the runtime-unique identifier of this signed extension
+		Id,
+	)>,
+);
+
+impl<Runtime, GrandpaInstance, Msgs, Refund, Priority, Id> RefundSignedExtension
+	for RefundBridgedGrandpaMessages<Runtime, GrandpaInstance, Msgs, Refund, Priority, Id>
 where
 	Self: 'static + Send + Sync,
 	Runtime: UtilityConfig<RuntimeCall = CallOf<Runtime>>
-		+ BoundedBridgeGrandpaConfig<Runtime::BridgesGrandpaPalletInstance>
-		+ ParachainsConfig<Para::Instance>
+		+ BoundedBridgeGrandpaConfig<GrandpaInstance>
 		+ MessagesConfig<Msgs::Instance>
 		+ RelayersConfig,
-	Para: RefundableParachainId,
+	GrandpaInstance: 'static,
 	Msgs: RefundableMessagesLaneId,
 	Refund: RefundCalculator<Balance = Runtime::Reward>,
 	Priority: Get<TransactionPriority>,
 	Id: StaticStrProvider,
 	CallOf<Runtime>: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>
 		+ IsSubType<CallableCallFor<UtilityPallet<Runtime>, Runtime>>
-		+ GrandpaCallSubType<Runtime, Runtime::BridgesGrandpaPalletInstance>
-		+ ParachainsCallSubType<Runtime, Para::Instance>
+		+ GrandpaCallSubType<Runtime, GrandpaInstance>
 		+ MessagesCallSubType<Runtime, Msgs::Instance>,
 {
-	const IDENTIFIER: &'static str = Id::STR;
-	type AccountId = Runtime::AccountId;
-	type Call = CallOf<Runtime>;
-	type AdditionalSigned = ();
-	type Pre = Option<PreDispatchData<Runtime::AccountId>>;
+	type Runtime = Runtime;
+	type GrandpaInstance = GrandpaInstance;
+	type Msgs = Msgs;
+	type Refund = Refund;
+	type Priority = Priority;
+	type Id = Id;
 
-	fn additional_signed(&self) -> Result<(), TransactionValidityError> {
-		Ok(())
-	}
-
-	fn validate(
-		&self,
-		who: &Self::AccountId,
-		call: &Self::Call,
-		_info: &DispatchInfoOf<Self::Call>,
-		_len: usize,
-	) -> TransactionValidity {
-		// this is the only relevant line of code for the `pre_dispatch`
-		//
-		// we're not calling `validate` from `pre_dispatch` directly because of performance
-		// reasons, so if you're adding some code that may fail here, please check if it needs
-		// to be added to the `pre_dispatch` as well
-		let parsed_call = self.parse_and_check_for_obsolete_call(call)?;
-
-		// the following code just plays with transaction priority and never returns an error
-
-		// we only boost priority of presumably correct message delivery transactions
-		let bundled_messages = match Self::bundled_messages_for_priority_boost(parsed_call.as_ref())
-		{
-			Some(bundled_messages) => bundled_messages,
-			None => return Ok(Default::default()),
-		};
-
-		// we only boost priority if relayer has staked required balance
-		if !RelayersPallet::<Runtime>::is_registration_active(who) {
-			return Ok(Default::default())
+	fn expand_call(call: &CallOf<Runtime>) -> Vec<&CallOf<Runtime>> {
+		match call.is_sub_type() {
+			Some(UtilityCall::<Runtime>::batch_all { ref calls }) if calls.len() <= 2 =>
+				calls.iter().collect(),
+			Some(_) => vec![],
+			None => vec![call],
 		}
-
-		// compute priority boost
-		let priority_boost =
-			crate::priority_calculator::compute_priority_boost::<Priority>(bundled_messages);
-		let valid_transaction = ValidTransactionBuilder::default().priority(priority_boost);
-
-		log::trace!(
-			target: "runtime::bridge",
-			"{} from parachain {} via {:?} has boosted priority of message delivery transaction \
-			of relayer {:?}: {} messages -> {} priority",
-			Self::IDENTIFIER,
-			Para::Id::get(),
-			Msgs::Id::get(),
-			who,
-			bundled_messages,
-			priority_boost,
-		);
-
-		valid_transaction.build()
 	}
 
-	fn pre_dispatch(
-		self,
-		who: &Self::AccountId,
-		call: &Self::Call,
-		_info: &DispatchInfoOf<Self::Call>,
-		_len: usize,
-	) -> Result<Self::Pre, TransactionValidityError> {
-		// this is a relevant piece of `validate` that we need here (in `pre_dispatch`)
-		let parsed_call = self.parse_and_check_for_obsolete_call(call)?;
+	fn parse_and_check_for_obsolete_call(
+		call: &CallOf<Runtime>,
+	) -> Result<Option<CallInfo>, TransactionValidityError> {
+		let calls = Self::expand_call(call);
+		let total_calls = calls.len();
+		let mut calls = calls.into_iter().map(Self::check_obsolete_parsed_call).rev();
 
-		Ok(parsed_call.map(|call_info| {
-			log::trace!(
-				target: "runtime::bridge",
-				"{} from parachain {} via {:?} parsed bridge transaction in pre-dispatch: {:?}",
-				Self::IDENTIFIER,
-				Para::Id::get(),
-				Msgs::Id::get(),
-				call_info,
-			);
-			PreDispatchData { relayer: who.clone(), call_info }
-		}))
+		let msgs_call = calls.next().transpose()?.and_then(|c| c.call_info_for(Msgs::Id::get()));
+		let relay_finality_call =
+			calls.next().transpose()?.and_then(|c| c.submit_finality_proof_info());
+
+		Ok(match (total_calls, relay_finality_call, msgs_call) {
+			(2, Some(relay_finality_call), Some(msgs_call)) =>
+				Some(CallInfo::RelayFinalityAndMsgs(relay_finality_call, msgs_call)),
+			(1, None, Some(msgs_call)) => Some(CallInfo::Msgs(msgs_call)),
+			_ => None,
+		})
 	}
 
-	fn post_dispatch(
-		pre: Option<Self::Pre>,
-		info: &DispatchInfoOf<Self::Call>,
-		post_info: &PostDispatchInfoOf<Self::Call>,
-		len: usize,
-		result: &DispatchResult,
-	) -> Result<(), TransactionValidityError> {
-		let call_result = Self::analyze_call_result(pre, info, post_info, len, result);
+	fn check_obsolete_parsed_call(
+		call: &CallOf<Runtime>,
+	) -> Result<&CallOf<Runtime>, TransactionValidityError> {
+		call.check_obsolete_submit_finality_proof()?;
+		call.check_obsolete_call()?;
+		Ok(call)
+	}
 
-		match call_result {
-			RelayerAccountAction::None => (),
-			RelayerAccountAction::Reward(relayer, reward_account, reward) => {
-				RelayersPallet::<Runtime>::register_relayer_reward(
-					reward_account,
-					&relayer,
-					reward,
-				);
-
-				log::trace!(
-					target: "runtime::bridge",
-					"{} from parachain {} via {:?} has registered reward: {:?} for {:?}",
-					Self::IDENTIFIER,
-					Para::Id::get(),
-					Msgs::Id::get(),
-					reward,
-					relayer,
-				);
-			},
-			RelayerAccountAction::Slash(relayer, slash_account) =>
-				RelayersPallet::<Runtime>::slash_and_deregister(&relayer, slash_account),
-		}
-
-		Ok(())
+	fn additional_call_result_check(_relayer: &Runtime::AccountId, _call_info: &CallInfo) -> bool {
+		true
 	}
 }
 
@@ -690,7 +872,17 @@ mod tests {
 	}
 
 	bp_runtime::generate_static_str_provider!(TestExtension);
-	type TestExtension = RefundBridgedParachainMessages<
+
+	type TestGrandpaExtensionProvider = RefundBridgedGrandpaMessages<
+		TestRuntime,
+		(),
+		RefundableMessagesLane<(), TestLaneId>,
+		ActualFeeRefund<TestRuntime>,
+		ConstU64<1>,
+		StrTestExtension,
+	>;
+	type TestGrandpaExtension = RefundSignedExtensionAdapter<TestGrandpaExtensionProvider>;
+	type TestExtensionProvider = RefundBridgedParachainMessages<
 		TestRuntime,
 		DefaultRefundableParachainId<(), TestParachain>,
 		RefundableMessagesLane<(), TestLaneId>,
@@ -698,6 +890,7 @@ mod tests {
 		ConstU64<1>,
 		StrTestExtension,
 	>;
+	type TestExtension = RefundSignedExtensionAdapter<TestExtensionProvider>;
 
 	fn initial_balance_of_relayer_account_at_this_chain() -> ThisChainBalance {
 		let test_stake: ThisChainBalance = TestStake::get();
@@ -849,6 +1042,30 @@ mod tests {
 		})
 	}
 
+	fn relay_finality_and_delivery_batch_call(
+		relay_header_number: RelayBlockNumber,
+		best_message: MessageNonce,
+	) -> RuntimeCall {
+		RuntimeCall::Utility(UtilityCall::batch_all {
+			calls: vec![
+				submit_relay_header_call(relay_header_number),
+				message_delivery_call(best_message),
+			],
+		})
+	}
+
+	fn relay_finality_and_confirmation_batch_call(
+		relay_header_number: RelayBlockNumber,
+		best_message: MessageNonce,
+	) -> RuntimeCall {
+		RuntimeCall::Utility(UtilityCall::batch_all {
+			calls: vec![
+				submit_relay_header_call(relay_header_number),
+				message_confirmation_call(best_message),
+			],
+		})
+	}
+
 	fn all_finality_and_delivery_batch_call(
 		relay_header_number: RelayBlockNumber,
 		parachain_head_at_relay_header_number: RelayBlockNumber,
@@ -919,6 +1136,50 @@ mod tests {
 					at_relay_block_number: 200,
 					para_id: ParaId(TestParachain::get()),
 					para_head_hash: [200u8; 32].into(),
+				},
+				MessagesCallInfo::ReceiveMessagesDeliveryProof(ReceiveMessagesDeliveryProofInfo(
+					BaseMessagesProofInfo {
+						lane_id: TEST_LANE_ID,
+						bundled_range: 101..=200,
+						best_stored_nonce: 100,
+					},
+				)),
+			),
+		}
+	}
+
+	fn relay_finality_pre_dispatch_data() -> PreDispatchData<ThisChainAccountId> {
+		PreDispatchData {
+			relayer: relayer_account_at_this_chain(),
+			call_info: CallInfo::RelayFinalityAndMsgs(
+				SubmitFinalityProofInfo {
+					block_number: 200,
+					extra_weight: Weight::zero(),
+					extra_size: 0,
+				},
+				MessagesCallInfo::ReceiveMessagesProof(ReceiveMessagesProofInfo {
+					base: BaseMessagesProofInfo {
+						lane_id: TEST_LANE_ID,
+						bundled_range: 101..=200,
+						best_stored_nonce: 100,
+					},
+					unrewarded_relayers: UnrewardedRelayerOccupation {
+						free_relayer_slots: MaxUnrewardedRelayerEntriesAtInboundLane::get(),
+						free_message_slots: MaxUnconfirmedMessagesAtInboundLane::get(),
+					},
+				}),
+			),
+		}
+	}
+
+	fn relay_finality_confirmation_pre_dispatch_data() -> PreDispatchData<ThisChainAccountId> {
+		PreDispatchData {
+			relayer: relayer_account_at_this_chain(),
+			call_info: CallInfo::RelayFinalityAndMsgs(
+				SubmitFinalityProofInfo {
+					block_number: 200,
+					extra_weight: Weight::zero(),
+					extra_size: 0,
 				},
 				MessagesCallInfo::ReceiveMessagesDeliveryProof(ReceiveMessagesDeliveryProofInfo(
 					BaseMessagesProofInfo {
@@ -1013,6 +1274,7 @@ mod tests {
 	) -> PreDispatchData<ThisChainAccountId> {
 		let msg_info = match pre_dispatch_data.call_info {
 			CallInfo::AllFinalityAndMsgs(_, _, ref mut info) => info,
+			CallInfo::RelayFinalityAndMsgs(_, ref mut info) => info,
 			CallInfo::ParachainFinalityAndMsgs(_, ref mut info) => info,
 			CallInfo::Msgs(ref mut info) => info,
 		};
@@ -1025,7 +1287,14 @@ mod tests {
 	}
 
 	fn run_validate(call: RuntimeCall) -> TransactionValidity {
-		let extension: TestExtension = RefundBridgedParachainMessages(PhantomData);
+		let extension: TestExtension =
+			RefundSignedExtensionAdapter(RefundBridgedParachainMessages(PhantomData));
+		extension.validate(&relayer_account_at_this_chain(), &call, &DispatchInfo::default(), 0)
+	}
+
+	fn run_grandpa_validate(call: RuntimeCall) -> TransactionValidity {
+		let extension: TestGrandpaExtension =
+			RefundSignedExtensionAdapter(RefundBridgedGrandpaMessages(PhantomData));
 		extension.validate(&relayer_account_at_this_chain(), &call, &DispatchInfo::default(), 0)
 	}
 
@@ -1039,7 +1308,16 @@ mod tests {
 	fn run_pre_dispatch(
 		call: RuntimeCall,
 	) -> Result<Option<PreDispatchData<ThisChainAccountId>>, TransactionValidityError> {
-		let extension: TestExtension = RefundBridgedParachainMessages(PhantomData);
+		let extension: TestExtension =
+			RefundSignedExtensionAdapter(RefundBridgedParachainMessages(PhantomData));
+		extension.pre_dispatch(&relayer_account_at_this_chain(), &call, &DispatchInfo::default(), 0)
+	}
+
+	fn run_grandpa_pre_dispatch(
+		call: RuntimeCall,
+	) -> Result<Option<PreDispatchData<ThisChainAccountId>>, TransactionValidityError> {
+		let extension: TestGrandpaExtension =
+			RefundSignedExtensionAdapter(RefundBridgedGrandpaMessages(PhantomData));
 		extension.pre_dispatch(&relayer_account_at_this_chain(), &call, &DispatchInfo::default(), 0)
 	}
 
@@ -1674,7 +1952,7 @@ mod tests {
 		pre_dispatch_data: PreDispatchData<ThisChainAccountId>,
 		dispatch_result: DispatchResult,
 	) -> RelayerAccountAction<ThisChainAccountId, ThisChainBalance> {
-		TestExtension::analyze_call_result(
+		TestExtensionProvider::analyze_call_result(
 			Some(Some(pre_dispatch_data)),
 			&dispatch_info(),
 			&post_dispatch_info(),
@@ -1734,6 +2012,177 @@ mod tests {
 					Ok(())
 				),
 				RelayerAccountAction::None,
+			);
+		});
+	}
+
+	#[test]
+	fn grandpa_ext_only_parses_valid_batches() {
+		run_test(|| {
+			initialize_environment(100, 100, 100);
+
+			// relay + parachain + message delivery calls batch is ignored
+			assert_eq!(
+				TestGrandpaExtensionProvider::parse_and_check_for_obsolete_call(
+					&all_finality_and_delivery_batch_call(200, 200, 200)
+				),
+				Ok(None),
+			);
+
+			// relay + parachain + message confirmation calls batch is ignored
+			assert_eq!(
+				TestGrandpaExtensionProvider::parse_and_check_for_obsolete_call(
+					&all_finality_and_confirmation_batch_call(200, 200, 200)
+				),
+				Ok(None),
+			);
+
+			// parachain + message delivery call batch is ignored
+			assert_eq!(
+				TestGrandpaExtensionProvider::parse_and_check_for_obsolete_call(
+					&parachain_finality_and_delivery_batch_call(200, 200)
+				),
+				Ok(None),
+			);
+
+			// parachain + message confirmation call batch is ignored
+			assert_eq!(
+				TestGrandpaExtensionProvider::parse_and_check_for_obsolete_call(
+					&parachain_finality_and_confirmation_batch_call(200, 200)
+				),
+				Ok(None),
+			);
+
+			// relay + message delivery call batch is accepted
+			assert_eq!(
+				TestGrandpaExtensionProvider::parse_and_check_for_obsolete_call(
+					&relay_finality_and_delivery_batch_call(200, 200)
+				),
+				Ok(Some(relay_finality_pre_dispatch_data().call_info)),
+			);
+
+			// relay + message confirmation call batch is accepted
+			assert_eq!(
+				TestGrandpaExtensionProvider::parse_and_check_for_obsolete_call(
+					&relay_finality_and_confirmation_batch_call(200, 200)
+				),
+				Ok(Some(relay_finality_confirmation_pre_dispatch_data().call_info)),
+			);
+
+			// message delivery call batch is accepted
+			assert_eq!(
+				TestGrandpaExtensionProvider::parse_and_check_for_obsolete_call(
+					&message_delivery_call(200)
+				),
+				Ok(Some(delivery_pre_dispatch_data().call_info)),
+			);
+
+			// message confirmation call batch is accepted
+			assert_eq!(
+				TestGrandpaExtensionProvider::parse_and_check_for_obsolete_call(
+					&message_confirmation_call(200)
+				),
+				Ok(Some(confirmation_pre_dispatch_data().call_info)),
+			);
+		});
+	}
+
+	#[test]
+	fn grandpa_ext_rejects_batch_with_obsolete_relay_chain_header() {
+		run_test(|| {
+			initialize_environment(100, 100, 100);
+
+			assert_eq!(
+				run_grandpa_pre_dispatch(relay_finality_and_delivery_batch_call(100, 200)),
+				Err(TransactionValidityError::Invalid(InvalidTransaction::Stale)),
+			);
+
+			assert_eq!(
+				run_grandpa_validate(relay_finality_and_delivery_batch_call(100, 200)),
+				Err(TransactionValidityError::Invalid(InvalidTransaction::Stale)),
+			);
+		});
+	}
+
+	#[test]
+	fn grandpa_ext_rejects_calls_with_obsolete_messages() {
+		run_test(|| {
+			initialize_environment(100, 100, 100);
+
+			assert_eq!(
+				run_grandpa_pre_dispatch(relay_finality_and_delivery_batch_call(200, 100)),
+				Err(TransactionValidityError::Invalid(InvalidTransaction::Stale)),
+			);
+			assert_eq!(
+				run_grandpa_pre_dispatch(relay_finality_and_confirmation_batch_call(200, 100)),
+				Err(TransactionValidityError::Invalid(InvalidTransaction::Stale)),
+			);
+
+			assert_eq!(
+				run_grandpa_validate(relay_finality_and_delivery_batch_call(200, 100)),
+				Err(TransactionValidityError::Invalid(InvalidTransaction::Stale)),
+			);
+			assert_eq!(
+				run_grandpa_validate(relay_finality_and_confirmation_batch_call(200, 100)),
+				Err(TransactionValidityError::Invalid(InvalidTransaction::Stale)),
+			);
+
+			assert_eq!(
+				run_grandpa_pre_dispatch(message_delivery_call(100)),
+				Err(TransactionValidityError::Invalid(InvalidTransaction::Stale)),
+			);
+			assert_eq!(
+				run_grandpa_pre_dispatch(message_confirmation_call(100)),
+				Err(TransactionValidityError::Invalid(InvalidTransaction::Stale)),
+			);
+
+			assert_eq!(
+				run_grandpa_validate(message_delivery_call(100)),
+				Err(TransactionValidityError::Invalid(InvalidTransaction::Stale)),
+			);
+			assert_eq!(
+				run_grandpa_validate(message_confirmation_call(100)),
+				Err(TransactionValidityError::Invalid(InvalidTransaction::Stale)),
+			);
+		});
+	}
+
+	#[test]
+	fn grandpa_ext_accepts_calls_with_new_messages() {
+		run_test(|| {
+			initialize_environment(100, 100, 100);
+
+			assert_eq!(
+				run_grandpa_pre_dispatch(relay_finality_and_delivery_batch_call(200, 200)),
+				Ok(Some(relay_finality_pre_dispatch_data()),)
+			);
+			assert_eq!(
+				run_grandpa_pre_dispatch(relay_finality_and_confirmation_batch_call(200, 200)),
+				Ok(Some(relay_finality_confirmation_pre_dispatch_data())),
+			);
+
+			assert_eq!(
+				run_grandpa_validate(relay_finality_and_delivery_batch_call(200, 200)),
+				Ok(Default::default()),
+			);
+			assert_eq!(
+				run_grandpa_validate(relay_finality_and_confirmation_batch_call(200, 200)),
+				Ok(Default::default()),
+			);
+
+			assert_eq!(
+				run_grandpa_pre_dispatch(message_delivery_call(200)),
+				Ok(Some(delivery_pre_dispatch_data())),
+			);
+			assert_eq!(
+				run_grandpa_pre_dispatch(message_confirmation_call(200)),
+				Ok(Some(confirmation_pre_dispatch_data())),
+			);
+
+			assert_eq!(run_grandpa_validate(message_delivery_call(200)), Ok(Default::default()),);
+			assert_eq!(
+				run_grandpa_validate(message_confirmation_call(200)),
+				Ok(Default::default()),
 			);
 		});
 	}

--- a/bridges/primitives/chain-bridge-hub-kusama/src/lib.rs
+++ b/bridges/primitives/chain-bridge-hub-kusama/src/lib.rs
@@ -29,7 +29,6 @@ use frame_support::{
 	sp_runtime::{MultiAddress, MultiSigner},
 };
 use sp_runtime::RuntimeDebug;
-use sp_std::prelude::Vec;
 
 /// BridgeHubKusama parachain.
 #[derive(RuntimeDebug)]

--- a/bridges/primitives/chain-bridge-hub-polkadot/src/lib.rs
+++ b/bridges/primitives/chain-bridge-hub-polkadot/src/lib.rs
@@ -26,7 +26,6 @@ use bp_runtime::{
 };
 use frame_support::dispatch::DispatchClass;
 use sp_runtime::RuntimeDebug;
-use sp_std::prelude::Vec;
 
 /// BridgeHubPolkadot parachain.
 #[derive(RuntimeDebug)]

--- a/bridges/primitives/chain-bridge-hub-rococo/src/lib.rs
+++ b/bridges/primitives/chain-bridge-hub-rococo/src/lib.rs
@@ -26,7 +26,6 @@ use bp_runtime::{
 };
 use frame_support::dispatch::DispatchClass;
 use sp_runtime::{MultiAddress, MultiSigner, RuntimeDebug};
-use sp_std::prelude::Vec;
 /// BridgeHubRococo parachain.
 #[derive(RuntimeDebug)]
 pub struct BridgeHubRococo;

--- a/bridges/primitives/chain-bridge-hub-wococo/src/lib.rs
+++ b/bridges/primitives/chain-bridge-hub-wococo/src/lib.rs
@@ -26,7 +26,6 @@ use bp_runtime::{
 };
 use frame_support::dispatch::DispatchClass;
 use sp_runtime::RuntimeDebug;
-use sp_std::prelude::Vec;
 
 /// BridgeHubWococo parachain.
 #[derive(RuntimeDebug)]

--- a/bridges/primitives/chain-kusama/src/lib.rs
+++ b/bridges/primitives/chain-kusama/src/lib.rs
@@ -23,7 +23,6 @@ pub use bp_polkadot_core::*;
 use bp_header_chain::ChainWithGrandpa;
 use bp_runtime::{decl_bridge_finality_runtime_apis, Chain};
 use frame_support::weights::Weight;
-use sp_std::prelude::Vec;
 
 /// Kusama Chain
 pub struct Kusama;

--- a/bridges/primitives/chain-polkadot-bulletin/Cargo.toml
+++ b/bridges/primitives/chain-polkadot-bulletin/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "bp-polkadot-bulletin"
+description = "Primitives of Polkadot Bulletin chain runtime."
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
+scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+
+# Bridge Dependencies
+
+bp-header-chain = { path = "../header-chain", default-features = false }
+bp-messages = { path = "../messages", default-features = false }
+bp-polkadot-core = { path = "../polkadot-core", default-features = false }
+bp-runtime = { path = "../runtime", default-features = false }
+
+# Substrate Based Dependencies
+
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"bp-header-chain/std",
+	"bp-messages/std",
+	"bp-polkadot-core/std",
+	"bp-runtime/std",
+	"codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"sp-api/std",
+	"sp-runtime/std",
+	"sp-std/std",
+]

--- a/bridges/primitives/chain-polkadot-bulletin/src/lib.rs
+++ b/bridges/primitives/chain-polkadot-bulletin/src/lib.rs
@@ -1,0 +1,215 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Polkadot Bulletin Chain primitives.
+
+#![warn(missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use bp_header_chain::ChainWithGrandpa;
+use bp_messages::MessageNonce;
+use bp_runtime::{
+	decl_bridge_finality_runtime_apis, decl_bridge_messages_runtime_apis,
+	extensions::{
+		CheckEra, CheckGenesis, CheckNonZeroSender, CheckNonce, CheckSpecVersion, CheckTxVersion,
+		CheckWeight, GenericSignedExtension, GenericSignedExtensionSchema,
+	},
+	Chain, TransactionEra,
+};
+use codec::{Decode, Encode};
+use frame_support::{
+	dispatch::DispatchClass,
+	parameter_types,
+	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
+};
+use frame_system::limits;
+use scale_info::TypeInfo;
+use sp_runtime::{traits::DispatchInfoOf, transaction_validity::TransactionValidityError, Perbill};
+
+// This chain reuses most of Polkadot primitives.
+pub use bp_polkadot_core::{
+	AccountAddress, AccountId, Balance, Block, BlockNumber, Hash, Hasher, Header, Nonce, Signature,
+	SignedBlock, UncheckedExtrinsic, AVERAGE_HEADER_SIZE_IN_JUSTIFICATION,
+	EXTRA_STORAGE_PROOF_SIZE, MAX_HEADER_SIZE, REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY,
+};
+
+/// Maximal number of GRANDPA authorities at Polkadot Bulletin chain.
+pub const MAX_AUTHORITIES_COUNT: u32 = 100;
+
+/// Name of the With-Polkadot Bulletin chain GRANDPA pallet instance that is deployed at bridged
+/// chains.
+pub const WITH_POLKADOT_BULLETIN_GRANDPA_PALLET_NAME: &str = "BridgePolkadotBulletinGrandpa";
+/// Name of the With-Polkadot Bulletin chain messages pallet instance that is deployed at bridged
+/// chains.
+pub const WITH_POLKADOT_BULLETIN_MESSAGES_PALLET_NAME: &str = "BridgePolkadotBulletinMessages";
+
+// There are fewer system operations on this chain (e.g. staking, governance, etc.). Use a higher
+// percentage of the block for data storage.
+const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(90);
+
+// Re following constants - we are using the same values at Cumulus parachains. They are limited
+// by the maximal transaction weight/size. Since block limits at Bulletin Chain are larger than
+// at the Cumulus Bridgeg Hubs, we could reuse the same values.
+
+/// Maximal number of unrewarded relayer entries at inbound lane for Cumulus-based parachains.
+pub const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce = 1024;
+
+/// Maximal number of unconfirmed messages at inbound lane for Cumulus-based parachains.
+pub const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce = 4096;
+
+/// This signed extension is used to ensure that the chain transactions are signed by proper
+pub type ValidateSigned = GenericSignedExtensionSchema<(), ()>;
+
+/// Signed extension schema, used by Polkadot Bulletin.
+pub type SignedExtensionSchema = GenericSignedExtension<(
+	(
+		CheckNonZeroSender,
+		CheckSpecVersion,
+		CheckTxVersion,
+		CheckGenesis<Hash>,
+		CheckEra<Hash>,
+		CheckNonce<Nonce>,
+		CheckWeight,
+	),
+	ValidateSigned,
+)>;
+
+/// Signed extension, used by Polkadot Bulletin.
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, TypeInfo)]
+pub struct SignedExtension(SignedExtensionSchema);
+
+impl sp_runtime::traits::SignedExtension for SignedExtension {
+	const IDENTIFIER: &'static str = "Not needed.";
+	type AccountId = ();
+	type Call = ();
+	type AdditionalSigned =
+		<SignedExtensionSchema as sp_runtime::traits::SignedExtension>::AdditionalSigned;
+	type Pre = ();
+
+	fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+		self.0.additional_signed()
+	}
+
+	fn pre_dispatch(
+		self,
+		_who: &Self::AccountId,
+		_call: &Self::Call,
+		_info: &DispatchInfoOf<Self::Call>,
+		_len: usize,
+	) -> Result<Self::Pre, TransactionValidityError> {
+		Ok(())
+	}
+}
+
+impl SignedExtension {
+	/// Create signed extension from its components.
+	pub fn from_params(
+		spec_version: u32,
+		transaction_version: u32,
+		era: TransactionEra<BlockNumber, Hash>,
+		genesis_hash: Hash,
+		nonce: Nonce,
+	) -> Self {
+		Self(GenericSignedExtension::new(
+			(
+				(
+					(),              // non-zero sender
+					(),              // spec version
+					(),              // tx version
+					(),              // genesis
+					era.frame_era(), // era
+					nonce.into(),    // nonce (compact encoding)
+					(),              // Check weight
+				),
+				(),
+			),
+			Some((
+				(
+					(),
+					spec_version,
+					transaction_version,
+					genesis_hash,
+					era.signed_payload(genesis_hash),
+					(),
+					(),
+				),
+				(),
+			)),
+		))
+	}
+
+	/// Return transaction nonce.
+	pub fn nonce(&self) -> Nonce {
+		let common_payload = self.0.payload.0;
+		common_payload.5 .0
+	}
+}
+
+parameter_types! {
+	/// We allow for 2 seconds of compute with a 6 second average block time.
+	pub BlockWeights: limits::BlockWeights = limits::BlockWeights::with_sensible_defaults(
+			Weight::from_parts(2u64 * WEIGHT_REF_TIME_PER_SECOND, u64::MAX),
+			NORMAL_DISPATCH_RATIO,
+		);
+	// Note: Max transaction size is 8 MB. Set max block size to 10 MB to facilitate data storage.
+	// This is double the "normal" Relay Chain block length limit.
+	/// Maximal block length at Polkadot Bulletin chain.
+	pub BlockLength: limits::BlockLength = limits::BlockLength::max_with_normal_ratio(
+		10 * 1024 * 1024,
+		NORMAL_DISPATCH_RATIO,
+	);
+}
+
+/// Polkadot Bulletin Chain declaration.
+pub struct PolkadotBulletin;
+
+impl Chain for PolkadotBulletin {
+	type BlockNumber = BlockNumber;
+	type Hash = Hash;
+	type Hasher = Hasher;
+	type Header = Header;
+
+	type AccountId = AccountId;
+	// The Bulletin Chain is a permissioned blockchain without any balances. Our `Chain` trait
+	// requires balance type, which is then used by various bridge infrastructure code. However
+	// this code is optional and we are not planning to use it in our bridge.
+	type Balance = Balance;
+	type Nonce = Nonce;
+	type Signature = Signature;
+
+	fn max_extrinsic_size() -> u32 {
+		*BlockLength::get().max.get(DispatchClass::Normal)
+	}
+
+	fn max_extrinsic_weight() -> Weight {
+		BlockWeights::get()
+			.get(DispatchClass::Normal)
+			.max_extrinsic
+			.unwrap_or(Weight::MAX)
+	}
+}
+
+impl ChainWithGrandpa for PolkadotBulletin {
+	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = WITH_POLKADOT_BULLETIN_GRANDPA_PALLET_NAME;
+	const MAX_AUTHORITIES_COUNT: u32 = MAX_AUTHORITIES_COUNT;
+	const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 =
+		REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY;
+	const MAX_HEADER_SIZE: u32 = MAX_HEADER_SIZE;
+	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = AVERAGE_HEADER_SIZE_IN_JUSTIFICATION;
+}
+
+decl_bridge_finality_runtime_apis!(polkadot_bulletin, grandpa);
+decl_bridge_messages_runtime_apis!(polkadot_bulletin);

--- a/bridges/primitives/chain-polkadot/src/lib.rs
+++ b/bridges/primitives/chain-polkadot/src/lib.rs
@@ -23,7 +23,6 @@ pub use bp_polkadot_core::*;
 use bp_header_chain::ChainWithGrandpa;
 use bp_runtime::{decl_bridge_finality_runtime_apis, extensions::PrevalidateAttests, Chain};
 use frame_support::weights::Weight;
-use sp_std::prelude::Vec;
 
 /// Polkadot Chain
 pub struct Polkadot;

--- a/bridges/primitives/chain-rococo/src/lib.rs
+++ b/bridges/primitives/chain-rococo/src/lib.rs
@@ -23,7 +23,6 @@ pub use bp_polkadot_core::*;
 use bp_header_chain::ChainWithGrandpa;
 use bp_runtime::{decl_bridge_finality_runtime_apis, Chain};
 use frame_support::{parameter_types, weights::Weight};
-use sp_std::prelude::Vec;
 
 /// Rococo Chain
 pub struct Rococo;

--- a/bridges/primitives/chain-wococo/src/lib.rs
+++ b/bridges/primitives/chain-wococo/src/lib.rs
@@ -26,7 +26,6 @@ pub use bp_rococo::{
 use bp_header_chain::ChainWithGrandpa;
 use bp_runtime::{decl_bridge_finality_runtime_apis, Chain};
 use frame_support::weights::Weight;
-use sp_std::prelude::Vec;
 
 /// Wococo Chain
 pub struct Wococo;

--- a/bridges/primitives/runtime/src/chain.rs
+++ b/bridges/primitives/runtime/src/chain.rs
@@ -311,7 +311,7 @@ macro_rules! decl_bridge_finality_runtime_apis {
 						$(
 							/// Returns the justifications accepted in the current block.
 							fn [<synced_headers_ $consensus:lower _info>](
-							) -> Vec<$justification_type>;
+							) -> sp_std::vec::Vec<$justification_type>;
 						)?
 					}
 				}
@@ -360,10 +360,10 @@ macro_rules! decl_bridge_messages_runtime_apis {
 						/// If some (or all) messages are missing from the storage, they'll also will
 						/// be missing from the resulting vector. The vector is ordered by the nonce.
 						fn message_details(
-							lane: LaneId,
-							begin: MessageNonce,
-							end: MessageNonce,
-						) -> Vec<OutboundMessageDetails>;
+							lane: bp_messages::LaneId,
+							begin: bp_messages::MessageNonce,
+							end: bp_messages::MessageNonce,
+						) -> sp_std::vec::Vec<bp_messages::OutboundMessageDetails>;
 					}
 
 					/// Inbound message lane API for messages sent by this chain.
@@ -376,9 +376,9 @@ macro_rules! decl_bridge_messages_runtime_apis {
 					pub trait [<From $chain:camel InboundLaneApi>] {
 						/// Return details of given inbound messages.
 						fn message_details(
-							lane: LaneId,
-							messages: Vec<(MessagePayload, OutboundMessageDetails)>,
-						) -> Vec<InboundMessageDetails>;
+							lane: bp_messages::LaneId,
+							messages: sp_std::vec::Vec<(bp_messages::MessagePayload, bp_messages::OutboundMessageDetails)>,
+						) -> sp_std::vec::Vec<bp_messages::InboundMessageDetails>;
 					}
 				}
 			}

--- a/bridges/primitives/runtime/src/lib.rs
+++ b/bridges/primitives/runtime/src/lib.rs
@@ -73,6 +73,9 @@ pub const MILLAU_CHAIN_ID: ChainId = *b"mlau";
 /// Polkadot chain id.
 pub const POLKADOT_CHAIN_ID: ChainId = *b"pdot";
 
+/// Polkadot Bulletin chain id.
+pub const POLKADOT_BULLETIN_CHAIN_ID: ChainId = *b"pdbc";
+
 /// Kusama chain id.
 pub const KUSAMA_CHAIN_ID: ChainId = *b"ksma";
 

--- a/node/src/benchmarking.rs
+++ b/node/src/benchmarking.rs
@@ -81,6 +81,7 @@ pub fn create_benchmark_extrinsic(
 		frame_system::CheckNonce::<runtime::Runtime>::from(nonce),
 		frame_system::CheckWeight::<runtime::Runtime>::new(),
 		runtime::ValidateSigned,
+		runtime::BridgeRejectObsoleteHeadersAndMessages,
 	);
 
 	let raw_payload = runtime::SignedPayload::from_raw(
@@ -92,6 +93,7 @@ pub fn create_benchmark_extrinsic(
 			runtime::VERSION.transaction_version,
 			genesis_hash,
 			best_hash,
+			(),
 			(),
 			(),
 			(),

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,7 +1,9 @@
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use polkadot_bulletin_chain_runtime::{
-	opaque::SessionKeys, AccountId, BabeConfig, RuntimeGenesisConfig, SessionConfig, Signature,
-	SudoConfig, SystemConfig, ValidatorSetConfig, BABE_GENESIS_EPOCH_CONFIG, WASM_BINARY,
+	opaque::SessionKeys, AccountId, BabeConfig, BridgePolkadotGrandpaConfig,
+	BridgePolkadotMessagesConfig, BridgePolkadotParachainsConfig, RuntimeGenesisConfig,
+	SessionConfig, Signature, SudoConfig, SystemConfig, ValidatorSetConfig,
+	BABE_GENESIS_EPOCH_CONFIG, WASM_BINARY,
 };
 use sc_service::ChainType;
 use sp_consensus_babe::AuthorityId as BabeId;
@@ -148,7 +150,19 @@ fn testnet_genesis(
 		im_online: Default::default(),
 		sudo: SudoConfig {
 			// Assign network admin rights.
-			key: Some(root_key),
+			key: Some(root_key.clone()),
+		},
+		bridge_polkadot_grandpa: BridgePolkadotGrandpaConfig {
+			owner: Some(root_key.clone()),
+			..Default::default()
+		},
+		bridge_polkadot_parachains: BridgePolkadotParachainsConfig {
+			owner: Some(root_key.clone()),
+			..Default::default()
+		},
+		bridge_polkadot_messages: BridgePolkadotMessagesConfig {
+			owner: Some(root_key),
+			..Default::default()
 		},
 	}
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -52,8 +52,33 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 pallet-transaction-storage = { version = "4.0.0-dev", default-features = false, path = "../pallets/transaction-storage" }
 pallet-validator-set = { version = "1.0.0", default-features = false, path = "../pallets/validator-set" }
 
+# Bridge dependencies
+bp-bridge-hub-polkadot = { version = "0.1.0", default-features = false, path = "../bridges/primitives/chain-bridge-hub-polkadot" }
+bp-header-chain = { version = "0.1.0", default-features = false, path = "../bridges/primitives/header-chain" }
+bp-messages = { version = "0.1.0", default-features = false, path = "../bridges/primitives/messages" }
+bp-parachains = { version = "0.1.0", default-features = false, path = "../bridges/primitives/parachains" }
+bp-polkadot = { version = "0.1.0", default-features = false, path = "../bridges/primitives/chain-polkadot" }
+bp-polkadot-bulletin = { version = "0.1.0", default-features = false, path = "../bridges/primitives/chain-polkadot-bulletin" }
+bp-polkadot-core = { version = "0.1.0", default-features = false, path = "../bridges/primitives/polkadot-core" }
+bp-runtime = { version = "0.1.0", default-features = false, path = "../bridges/primitives/runtime" }
+bridge-runtime-common = { version = "0.1.0", default-features = false, path = "../bridges/bin/runtime-common" }
+pallet-bridge-grandpa = { version = "0.1.0", default-features = false, path = "../bridges/modules/grandpa" }
+pallet-bridge-parachains = { version = "0.1.0", default-features = false, path = "../bridges/modules/parachains" }
+pallet-bridge-messages = { version = "0.1.0", default-features = false, path = "../bridges/modules/messages" }
+
+# XCM dependencies
+xcm = { version = "1.0.0", default-features = false, git = "https://github.com/paritytech/polkadot.git", branch = "release-v1.0.0" }
+
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", optional = true, branch = "polkadot-v1.0.0" }
+
+[dev-dependencies]
+bp-test-utils = { version = "0.1.0", path = "../bridges/primitives/test-utils" }
+bridge-runtime-common = { version = "0.1.0", features = ["integrity-test"], path = "../bridges/bin/runtime-common" }
+sp-io = { version = "23.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-keyring = { version = "24.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-trie = { version = "22.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+static_assertions = "1.1"
 
 [features]
 default = ["std"]
@@ -94,6 +119,21 @@ std = [
 
 	"pallet-transaction-storage/std",
 	"pallet-validator-set/std",
+
+	"bp-bridge-hub-polkadot/std",
+	"bp-header-chain/std",
+	"bp-messages/std",
+	"bp-parachains/std",
+	"bp-polkadot/std",
+	"bp-polkadot-bulletin/std",
+	"bp-polkadot-core/std",
+	"bp-runtime/std",
+	"bridge-runtime-common/std",
+	"pallet-bridge-grandpa/std",
+	"pallet-bridge-parachains/std",
+	"pallet-bridge-messages/std",
+
+	"xcm/std",
 
 	"substrate-wasm-builder",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -151,6 +151,11 @@ runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-system-benchmarking/runtime-benchmarks",
 
+	"bridge-runtime-common/runtime-benchmarks",
+	"pallet-bridge-grandpa/runtime-benchmarks",
+	"pallet-bridge-messages/runtime-benchmarks",
+	"pallet-bridge-parachains/runtime-benchmarks",
+
 	"pallet-transaction-storage/runtime-benchmarks",
 	"pallet-validator-set/runtime-benchmarks",
 ]

--- a/runtime/src/bridge_config.rs
+++ b/runtime/src/bridge_config.rs
@@ -67,9 +67,6 @@ parameter_types! {
 		Here.into(),
 		XCM_LANE,
 	);
-
-	/// XCM message that is never sent to anyone.
-	pub NeverSentMessage: Option<Xcm<()>> = None;
 }
 
 /// An instance of `pallet_bridge_grandpa` used to bridge with Polkadot.

--- a/runtime/src/bridge_config.rs
+++ b/runtime/src/bridge_config.rs
@@ -1,0 +1,806 @@
+//! With Polkadot Bridge Hub bridge configuration.
+
+use crate::{AccountId, Runtime, RuntimeEvent, RuntimeOrigin};
+
+use bp_messages::{
+	target_chain::{DispatchMessage, MessageDispatch},
+	LaneId, MessageNonce,
+};
+use bp_parachains::SingleParaStoredHeaderDataBuilder;
+use bp_runtime::{messages::MessageDispatchResult, ChainId, UnderlyingChainProvider};
+use bridge_runtime_common::{
+	messages::{
+		source::{
+			FromThisChainMaximalOutboundPayloadSize, FromThisChainMessageVerifier,
+			TargetHeaderChainAdapter,
+		},
+		target::SourceHeaderChainAdapter,
+		BridgedChainWithMessages, MessageBridge, ThisChainWithMessages,
+	},
+	messages_xcm_extension::{SenderAndLane, XcmAsPlainPayload},
+};
+use frame_support::{parameter_types, RuntimeDebug};
+use sp_runtime::transaction_validity::{InvalidTransaction, TransactionValidity};
+use sp_std::vec::Vec;
+use xcm::prelude::*;
+
+/// Lane that we are using to send and receive messages.
+pub const XCM_LANE: LaneId = LaneId([0, 0, 0, 0]);
+
+parameter_types! {
+	/// A set of message relayers, who are able to submit message delivery transactions
+	/// and physically deliver messages on this chain.
+	///
+	/// It can be changed by the governance later.
+	pub storage WhitelistedRelayers: Vec<AccountId> = {
+		crate::Sudo::key().map(|sudo_key| sp_std::vec![sudo_key]).unwrap_or_default()
+	};
+
+	/// A number of Polkadot mandatory headers that are accepted for free at every
+	/// **this chain** block.
+	pub const MaxFreePolkadotHeadersPerBlock: u32 = 4;
+	/// A number of Polkadot header digests that we keep in the storage.
+	pub const PolkadotHeadersToKeep: u32 = 1024;
+	/// A name of parachains pallet at Pokadot.
+	pub const AtPolkadotParasPalletName: &'static str = bp_polkadot::PARAS_PALLET_NAME;
+
+	/// The Polkadot Chain network ID.
+	pub const PolkadotNetwork: NetworkId = Polkadot;
+	/// Chain identifier of Polkadot Bridge Hub.
+	pub const BridgeHubPolkadotChainId: ChainId = bp_runtime::BRIDGE_HUB_POLKADOT_CHAIN_ID;
+	/// A number of Polkadot Bridge Hub head digests that we keep in the storage.
+	pub const BridgeHubPolkadotHeadsToKeep: u32 = 1024;
+	/// A maximal size of Polkadot Bridge Hub head digest.
+	pub const MaxPolkadotBrdgeHubHeadSize: u32 = bp_polkadot::MAX_NESTED_PARACHAIN_HEAD_DATA_SIZE;
+
+	/// All active outbound lanes.
+	pub const ActiveOutboundLanes: &'static [LaneId] = &[XCM_LANE];
+	/// Maximal number of unrewarded relayer entries.
+	pub const MaxUnrewardedRelayerEntriesAtInboundLane: MessageNonce =
+		bp_bridge_hub_polkadot::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
+	/// Maximal number of unconfirmed messages.
+	pub const MaxUnconfirmedMessagesAtInboundLane: MessageNonce =
+		bp_bridge_hub_polkadot::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
+
+	/// Sending chain location and lane used to communicate with Polkadot Bulletin chain.
+	pub FromPolkadotBulletinToBridgeHubPolkadotRoute: SenderAndLane = SenderAndLane::new(
+		Here.into(),
+		XCM_LANE,
+	);
+
+	/// XCM message that is never sent to anyone.
+	pub NeverSentMessage: Option<Xcm<()>> = None;
+}
+
+/// An instance of `pallet_bridge_grandpa` used to bridge with Polkadot.
+pub type WithPolkadotBridgeGrandpaInstance = ();
+/// An instance of `pallet_bridge_parachains` used to bridge with Polkadot.
+pub type WithPolkadotBridgeParachainsInstance = ();
+/// An instance of `pallet_bridge_messages` used to bridge with Polkadot Bridge Hub.
+pub type WithBridgeHubPolkadotMessagesInstance = ();
+
+impl pallet_bridge_grandpa::Config<WithPolkadotBridgeGrandpaInstance> for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = (); // TODO [bridge]: replace with benchmark results
+
+	type BridgedChain = bp_polkadot::Polkadot;
+	type MaxFreeMandatoryHeadersPerBlock = MaxFreePolkadotHeadersPerBlock;
+	type HeadersToKeep = PolkadotHeadersToKeep;
+}
+
+impl pallet_bridge_parachains::Config<WithPolkadotBridgeParachainsInstance> for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = (); // TODO [bridge]: replace with benchmark results
+
+	type BridgesGrandpaPalletInstance = WithPolkadotBridgeGrandpaInstance;
+	type ParasPalletName = AtPolkadotParasPalletName;
+	type ParaStoredHeaderDataBuilder =
+		SingleParaStoredHeaderDataBuilder<bp_bridge_hub_polkadot::BridgeHubPolkadot>;
+	type HeadsToKeep = BridgeHubPolkadotHeadsToKeep;
+	type MaxParaHeadDataSize = MaxPolkadotBrdgeHubHeadSize;
+}
+
+impl pallet_bridge_messages::Config<WithBridgeHubPolkadotMessagesInstance> for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = (); // TODO [bridge]: replace with benchmark results
+
+	type BridgedChainId = BridgeHubPolkadotChainId;
+	type ActiveOutboundLanes = ActiveOutboundLanes;
+	type MaxUnrewardedRelayerEntriesAtInboundLane = MaxUnrewardedRelayerEntriesAtInboundLane;
+	type MaxUnconfirmedMessagesAtInboundLane = MaxUnconfirmedMessagesAtInboundLane;
+
+	type MaximalOutboundPayloadSize =
+		FromThisChainMaximalOutboundPayloadSize<WithBridgeHubPolkadotMessageBridge>;
+	type OutboundPayload = XcmAsPlainPayload;
+
+	type InboundPayload = XcmAsPlainPayload;
+	type InboundRelayer = AccountId;
+	type DeliveryPayments = ();
+
+	type TargetHeaderChain = TargetHeaderChainAdapter<WithBridgeHubPolkadotMessageBridge>;
+	type LaneMessageVerifier = FromThisChainMessageVerifier<WithBridgeHubPolkadotMessageBridge>;
+	type DeliveryConfirmationPayments = ();
+
+	type SourceHeaderChain = SourceHeaderChainAdapter<WithBridgeHubPolkadotMessageBridge>;
+	type MessageDispatch = FromBridgeHubPolkadotBlobDispatcher;
+	type OnMessagesDelivered = ();
+}
+
+/// Message bridge with Polkadot Bridge Hub.
+pub struct WithBridgeHubPolkadotMessageBridge;
+
+/// Polkadot Bridge Hub headers provider.
+pub type BridgeHubPolkadotHeadersProvider = pallet_bridge_parachains::ParachainHeaders<
+	Runtime,
+	WithPolkadotBridgeParachainsInstance,
+	bp_bridge_hub_polkadot::BridgeHubPolkadot,
+>;
+
+impl MessageBridge for WithBridgeHubPolkadotMessageBridge {
+	const BRIDGED_MESSAGES_PALLET_NAME: &'static str =
+		bp_polkadot_bulletin::WITH_POLKADOT_BULLETIN_MESSAGES_PALLET_NAME;
+	type ThisChain = PolkadotBulletinChain;
+	type BridgedChain = BridgeHubPolkadot;
+	type BridgedHeaderChain = BridgeHubPolkadotHeadersProvider;
+}
+
+/// BridgeHubPolkadot chain from message lane point of view.
+#[derive(RuntimeDebug, Clone, Copy)]
+pub struct BridgeHubPolkadot;
+
+impl UnderlyingChainProvider for BridgeHubPolkadot {
+	type Chain = bp_bridge_hub_polkadot::BridgeHubPolkadot;
+}
+
+impl BridgedChainWithMessages for BridgeHubPolkadot {}
+
+/// BridgeHubRococo chain from message lane point of view.
+#[derive(RuntimeDebug, Clone, Copy)]
+pub struct PolkadotBulletinChain;
+
+impl UnderlyingChainProvider for PolkadotBulletinChain {
+	type Chain = bp_polkadot_bulletin::PolkadotBulletin;
+}
+
+impl ThisChainWithMessages for PolkadotBulletinChain {
+	type RuntimeOrigin = RuntimeOrigin;
+}
+
+// TODO [bridge]: replace with immediate XCM dispatcher
+/// Dispatches received XCM messages from the Polkadot Bridge Hub.
+pub struct FromBridgeHubPolkadotBlobDispatcher;
+
+impl MessageDispatch for FromBridgeHubPolkadotBlobDispatcher {
+	type DispatchPayload = XcmAsPlainPayload;
+	type DispatchLevelResult = ();
+
+	fn is_active() -> bool {
+		true
+	}
+
+	fn dispatch_weight(_message: &mut DispatchMessage<Self::DispatchPayload>) -> Weight {
+		Weight::zero()
+	}
+
+	fn dispatch(
+		_: DispatchMessage<Self::DispatchPayload>,
+	) -> MessageDispatchResult<Self::DispatchLevelResult> {
+		MessageDispatchResult { unspent_weight: Weight::zero(), dispatch_level_result: () }
+	}
+}
+
+/// Ensure that the account provided is the whitelisted relayer account.
+pub fn ensure_whitelisted_relayer(who: &AccountId) -> TransactionValidity {
+	if !WhitelistedRelayers::get().contains(who) {
+		return Err(InvalidTransaction::BadSigner.into())
+	}
+
+	Ok(Default::default())
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+	use super::*;
+	use crate::{
+		BridgePolkadotGrandpa, BridgePolkadotMessages, BridgeRejectObsoleteHeadersAndMessages,
+		Executive, RuntimeCall, Signature, SignedExtra, SignedPayload, UncheckedExtrinsic,
+		ValidateSigned,
+	};
+	use bp_header_chain::{justification::GrandpaJustification, HeaderChain, InitializationData};
+	use bp_messages::{
+		DeliveredMessages, InboundLaneData, OutboundLaneData, UnrewardedRelayer,
+		UnrewardedRelayersState,
+	};
+	use bp_polkadot_core::parachains::{ParaHead, ParaHeadsProof};
+	use bp_runtime::{
+		record_all_trie_keys, BasicOperatingMode, HeaderIdProvider, Parachain, RawStorageProof,
+		StorageProofSize,
+	};
+	use bridge_runtime_common::{
+		assert_complete_bridge_types,
+		integrity::{
+			assert_complete_bridge_constants, check_message_lane_weights,
+			AssertBridgeMessagesPalletConstants, AssertBridgePalletNames, AssertChainConstants,
+			AssertCompleteBridgeConstants,
+		},
+		messages::{
+			source::FromBridgedChainMessagesDeliveryProof, target::FromBridgedChainMessagesProof,
+		},
+		messages_generation::{
+			encode_all_messages, encode_lane_data, prepare_messages_storage_proof,
+		},
+	};
+	use codec::Encode;
+	use frame_support::assert_ok;
+	use sp_api::HeaderT;
+	use sp_consensus_grandpa::{AuthorityList, SetId};
+	use sp_keyring::AccountKeyring;
+	use sp_runtime::{generic::Era, transaction_validity::TransactionValidityError, BuildStorage};
+	use sp_trie::{trie_types::TrieDBMutBuilderV1, LayoutV1, MemoryDB, TrieMut};
+
+	const POLKADOT_HEADER_NUMBER: bp_polkadot::BlockNumber = 100;
+	const BRIDGE_HUB_HEADER_NUMBER: bp_bridge_hub_polkadot::BlockNumber = 200;
+
+	#[derive(Clone, Copy)]
+	enum HeaderType {
+		WithMessages,
+		WithDeliveredMessages,
+	}
+
+	fn relayer_account_at_polkadot() -> bp_polkadot::AccountId {
+		[42u8; 32].into()
+	}
+
+	fn sudo_signer() -> AccountKeyring {
+		AccountKeyring::Alice
+	}
+
+	fn relayer_signer() -> AccountKeyring {
+		AccountKeyring::Bob
+	}
+
+	fn non_relay_signer() -> AccountKeyring {
+		AccountKeyring::Charlie
+	}
+
+	fn polkadot_initial_header() -> bp_polkadot::Header {
+		bp_test_utils::test_header(POLKADOT_HEADER_NUMBER - 1)
+	}
+
+	fn polkadot_header(t: HeaderType) -> bp_polkadot::Header {
+		let bridge_hub_polkadot_head_storage_proof = bridge_hub_polkadot_head_storage_proof(t);
+		let state_root = bridge_hub_polkadot_head_storage_proof.0;
+		bp_test_utils::test_header_with_root(POLKADOT_HEADER_NUMBER, state_root)
+	}
+
+	fn polkadot_grandpa_justification(t: HeaderType) -> GrandpaJustification<bp_polkadot::Header> {
+		bp_test_utils::make_default_justification(&polkadot_header(t))
+	}
+
+	fn bridge_hub_polkadot_header(t: HeaderType) -> bp_bridge_hub_polkadot::Header {
+		bp_test_utils::test_header_with_root(
+			BRIDGE_HUB_HEADER_NUMBER,
+			match t {
+				HeaderType::WithMessages => bridge_hub_polkadot_message_storage_proof().0,
+				HeaderType::WithDeliveredMessages =>
+					bridge_hub_polkadot_message_delivery_storage_proof().0,
+			},
+		)
+	}
+
+	fn bridge_hub_polkadot_head_storage_proof(
+		t: HeaderType,
+	) -> (bp_polkadot::Hash, ParaHeadsProof) {
+		let (state_root, proof, _) =
+			bp_test_utils::prepare_parachain_heads_proof::<bp_polkadot::Header>(vec![(
+				bp_bridge_hub_polkadot::BridgeHubPolkadot::PARACHAIN_ID,
+				ParaHead(bridge_hub_polkadot_header(t).encode()),
+			)]);
+		(state_root, proof)
+	}
+
+	fn bridge_hub_polkadot_message_storage_proof() -> (bp_bridge_hub_polkadot::Hash, RawStorageProof)
+	{
+		prepare_messages_storage_proof::<WithBridgeHubPolkadotMessageBridge>(
+			XCM_LANE,
+			1..=1,
+			None,
+			StorageProofSize::Minimal(0),
+			vec![42],
+			encode_all_messages,
+			encode_lane_data,
+		)
+	}
+
+	fn bridge_hub_polkadot_message_proof(
+	) -> FromBridgedChainMessagesProof<bp_bridge_hub_polkadot::Hash> {
+		let (_, storage_proof) = bridge_hub_polkadot_message_storage_proof();
+		let bridged_header_hash = bridge_hub_polkadot_header(HeaderType::WithMessages).hash();
+		FromBridgedChainMessagesProof {
+			bridged_header_hash,
+			storage_proof,
+			lane: XCM_LANE,
+			nonces_start: 1,
+			nonces_end: 1,
+		}
+	}
+
+	fn bridge_hub_polkadot_message_delivery_storage_proof(
+	) -> (bp_bridge_hub_polkadot::Hash, RawStorageProof) {
+		let storage_key = bp_messages::storage_keys::inbound_lane_data_key(
+			WithBridgeHubPolkadotMessageBridge::BRIDGED_MESSAGES_PALLET_NAME,
+			&XCM_LANE,
+		)
+		.0;
+		let storage_value = InboundLaneData::<AccountId> {
+			relayers: vec![UnrewardedRelayer {
+				relayer: relayer_signer().into(),
+				messages: DeliveredMessages { begin: 1, end: 1 },
+			}]
+			.into(),
+			last_confirmed_nonce: 0,
+		}
+		.encode();
+		let mut root = Default::default();
+		let mut mdb = MemoryDB::default();
+		{
+			let mut trie =
+				TrieDBMutBuilderV1::<bp_bridge_hub_polkadot::Hasher>::new(&mut mdb, &mut root)
+					.build();
+			trie.insert(&storage_key, &storage_value).unwrap();
+		}
+
+		let storage_proof =
+			record_all_trie_keys::<LayoutV1<bp_bridge_hub_polkadot::Hasher>, _>(&mdb, &root)
+				.unwrap();
+
+		(root, storage_proof)
+	}
+
+	fn bridge_hub_polkadot_message_delivery_proof(
+	) -> FromBridgedChainMessagesDeliveryProof<bp_bridge_hub_polkadot::Hash> {
+		let (_, storage_proof) = bridge_hub_polkadot_message_delivery_storage_proof();
+		let bridged_header_hash =
+			bridge_hub_polkadot_header(HeaderType::WithDeliveredMessages).hash();
+		FromBridgedChainMessagesDeliveryProof { bridged_header_hash, storage_proof, lane: XCM_LANE }
+	}
+
+	fn polkadot_authority_set() -> AuthorityList {
+		bp_test_utils::authority_list()
+	}
+
+	fn polkadot_authority_set_id() -> SetId {
+		1
+	}
+
+	// normally we would simply use `RuntimeCall::dispatch` in tests, but we need to test
+	// signed extension here, so we need to generate full-scale transaction and dispatch
+	// it using `Executive`
+	fn construct_and_apply_extrinsic(
+		signer: AccountKeyring,
+		call: RuntimeCall,
+	) -> sp_runtime::ApplyExtrinsicResult {
+		let nonce = frame_system::Account::<Runtime>::get(AccountId::from(signer.clone())).nonce;
+		let extra: SignedExtra = (
+			frame_system::CheckNonZeroSender::<Runtime>::new(),
+			frame_system::CheckSpecVersion::<Runtime>::new(),
+			frame_system::CheckTxVersion::<Runtime>::new(),
+			frame_system::CheckGenesis::<Runtime>::new(),
+			frame_system::CheckEra::<Runtime>::from(Era::immortal()),
+			frame_system::CheckNonce::<Runtime>::from(nonce),
+			frame_system::CheckWeight::<Runtime>::new(),
+			ValidateSigned,
+			BridgeRejectObsoleteHeadersAndMessages,
+		);
+		let payload = SignedPayload::new(call.clone(), extra.clone()).unwrap();
+		let signature = payload.using_encoded(|e| signer.sign(e));
+		Executive::apply_extrinsic(UncheckedExtrinsic::new_signed(
+			call,
+			AccountId::from(signer.public()).into(),
+			Signature::Sr25519(signature.clone()),
+			extra,
+		))
+	}
+
+	fn assert_ok_ok(apply_result: sp_runtime::ApplyExtrinsicResult) {
+		assert_ok!(apply_result);
+		assert_ok!(apply_result.unwrap());
+	}
+
+	pub fn run_test<T>(test: impl FnOnce() -> T) -> T {
+		let mut t = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
+		pallet_sudo::GenesisConfig::<Runtime> { key: Some(sudo_signer().into()) }
+			.assimilate_storage(&mut t)
+			.unwrap();
+
+		sp_io::TestExternalities::new(t).execute_with(|| test())
+	}
+
+	fn initialize_polkadot_grandpa_pallet() -> sp_runtime::ApplyExtrinsicResult {
+		construct_and_apply_extrinsic(
+			sudo_signer(),
+			RuntimeCall::Sudo(pallet_sudo::Call::sudo {
+				call: Box::new(RuntimeCall::BridgePolkadotGrandpa(
+					pallet_bridge_grandpa::Call::initialize {
+						init_data: InitializationData {
+							header: Box::new(polkadot_initial_header()),
+							authority_list: polkadot_authority_set(),
+							set_id: polkadot_authority_set_id(),
+							operating_mode: BasicOperatingMode::Normal,
+						},
+					},
+				)),
+			}),
+		)
+	}
+
+	fn submit_polkadot_header(
+		signer: AccountKeyring,
+		t: HeaderType,
+	) -> sp_runtime::ApplyExtrinsicResult {
+		construct_and_apply_extrinsic(
+			signer,
+			RuntimeCall::BridgePolkadotGrandpa(
+				pallet_bridge_grandpa::Call::submit_finality_proof {
+					finality_target: Box::new(polkadot_header(t)),
+					justification: polkadot_grandpa_justification(t),
+				},
+			),
+		)
+	}
+
+	fn submit_polkadot_bridge_hub_header(
+		signer: AccountKeyring,
+		t: HeaderType,
+	) -> sp_runtime::ApplyExtrinsicResult {
+		construct_and_apply_extrinsic(
+			signer,
+			RuntimeCall::BridgePolkadotParachains(
+				pallet_bridge_parachains::Call::submit_parachain_heads {
+					at_relay_block: (POLKADOT_HEADER_NUMBER, polkadot_header(t).hash()),
+					parachains: vec![(
+						bp_bridge_hub_polkadot::BridgeHubPolkadot::PARACHAIN_ID.into(),
+						bridge_hub_polkadot_header(t).hash(),
+					)],
+					parachain_heads_proof: bridge_hub_polkadot_head_storage_proof(t).1,
+				},
+			),
+		)
+	}
+
+	fn submit_messages_from_polkadot_bridge_hub(
+		signer: AccountKeyring,
+	) -> sp_runtime::ApplyExtrinsicResult {
+		construct_and_apply_extrinsic(
+			signer,
+			RuntimeCall::BridgePolkadotMessages(
+				pallet_bridge_messages::Call::receive_messages_proof {
+					relayer_id_at_bridged_chain: relayer_account_at_polkadot(),
+					proof: bridge_hub_polkadot_message_proof(),
+					messages_count: 1,
+					dispatch_weight: Weight::zero(),
+				},
+			),
+		)
+	}
+
+	fn submit_confirmations_from_polkadot_bridge_hub(
+		signer: AccountKeyring,
+	) -> sp_runtime::ApplyExtrinsicResult {
+		construct_and_apply_extrinsic(
+			signer,
+			RuntimeCall::BridgePolkadotMessages(
+				pallet_bridge_messages::Call::receive_messages_delivery_proof {
+					proof: bridge_hub_polkadot_message_delivery_proof(),
+					relayers_state: UnrewardedRelayersState {
+						unrewarded_relayer_entries: 1,
+						messages_in_oldest_entry: 1,
+						total_messages: 1,
+						last_delivered_nonce: 1,
+					},
+				},
+			),
+		)
+	}
+
+	fn emulate_sent_messages() {
+		pallet_bridge_messages::OutboundLanes::<Runtime, WithBridgeHubPolkadotMessagesInstance>::insert(
+			XCM_LANE,
+			OutboundLaneData {
+				oldest_unpruned_nonce: 1,
+				latest_received_nonce: 0,
+				latest_generated_nonce: 1,
+			},
+		);
+	}
+
+	#[test]
+	fn sudo_account_is_in_whitelisted_relayers_by_default() {
+		run_test(|| {
+			// until it is explicitly changed, sudo may submit bridge transactions
+			assert_eq!(WhitelistedRelayers::get(), vec![sudo_signer().into()]);
+		})
+	}
+
+	#[test]
+	fn may_change_whitelisted_relayers_set_using_sudo() {
+		run_test(|| {
+			let whitelisted_relayers_key = WhitelistedRelayers::key().to_vec();
+			let new_whitelisted_relayers = vec![AccountId::from(relayer_signer())].encode();
+
+			// sudo may change the whitelisted relayers set
+			assert_ok_ok(construct_and_apply_extrinsic(
+				sudo_signer(),
+				RuntimeCall::Sudo(pallet_sudo::Call::sudo {
+					call: Box::new(RuntimeCall::System(frame_system::Call::set_storage {
+						items: vec![(whitelisted_relayers_key, new_whitelisted_relayers)],
+					})),
+				}),
+			));
+
+			// and then it itself is missing from the set
+			assert_eq!(WhitelistedRelayers::get(), vec![relayer_signer().into()]);
+		});
+	}
+
+	#[test]
+	fn may_initialize_grandpa_pallet_using_sudo() {
+		run_test(|| {
+			assert_eq!(BridgePolkadotGrandpa::best_finalized(), None);
+			assert_ok_ok(initialize_polkadot_grandpa_pallet());
+			assert_eq!(
+				BridgePolkadotGrandpa::best_finalized(),
+				Some(polkadot_initial_header().id())
+			);
+		});
+	}
+
+	#[test]
+	fn whitelisted_relayer_may_submit_polkadot_headers() {
+		run_test(|| {
+			WhitelistedRelayers::set(&vec![relayer_signer().into()]);
+			assert_ok_ok(initialize_polkadot_grandpa_pallet());
+
+			// whitelisted relayer may submit regular Polkadot headers delivery transactions
+			assert_eq!(
+				BridgePolkadotGrandpa::best_finalized(),
+				Some(polkadot_initial_header().id())
+			);
+			assert_ok_ok(submit_polkadot_header(relayer_signer(), HeaderType::WithMessages));
+			assert_eq!(
+				BridgePolkadotGrandpa::best_finalized(),
+				Some(polkadot_header(HeaderType::WithMessages).id())
+			);
+		})
+	}
+
+	#[test]
+	fn non_relayer_may_not_submit_polkadot_headers() {
+		run_test(|| {
+			run_test(|| {
+				assert_ok_ok(initialize_polkadot_grandpa_pallet());
+
+				// non-whitelisted account may submit regular Polkadot headers delivery transactions
+				assert_eq!(
+					BridgePolkadotGrandpa::best_finalized(),
+					Some(polkadot_initial_header().id())
+				);
+				// can't use assert_noop here, because we need to mutate storage inside
+				// the `construct_and_apply_extrinsic`
+				assert_eq!(
+					submit_polkadot_header(non_relay_signer(), HeaderType::WithMessages),
+					Err(TransactionValidityError::Invalid(InvalidTransaction::BadSigner))
+				);
+				assert_eq!(
+					BridgePolkadotGrandpa::best_finalized(),
+					Some(polkadot_initial_header().id())
+				);
+			})
+		})
+	}
+
+	#[test]
+	fn whitelisted_relayer_may_submit_polkadot_bridge_hub_headers() {
+		run_test(|| {
+			WhitelistedRelayers::set(&vec![relayer_signer().into()]);
+			assert_ok_ok(initialize_polkadot_grandpa_pallet());
+			assert_ok_ok(submit_polkadot_header(relayer_signer(), HeaderType::WithMessages));
+
+			// whitelisted relayer may submit regular Polkadot BH headers delivery transactions
+			assert_eq!(
+				BridgeHubPolkadotHeadersProvider::finalized_header_state_root(
+					bridge_hub_polkadot_header(HeaderType::WithMessages).hash()
+				),
+				None,
+			);
+			assert_ok_ok(submit_polkadot_bridge_hub_header(
+				relayer_signer(),
+				HeaderType::WithMessages,
+			));
+			assert_eq!(
+				BridgeHubPolkadotHeadersProvider::finalized_header_state_root(
+					bridge_hub_polkadot_header(HeaderType::WithMessages).hash()
+				),
+				Some(*bridge_hub_polkadot_header(HeaderType::WithMessages).state_root())
+			);
+		})
+	}
+
+	#[test]
+	fn non_relayer_may_not_submit_polkadot_bridge_hub_headers() {
+		run_test(|| {
+			assert_ok_ok(initialize_polkadot_grandpa_pallet());
+
+			// whitelisted relayer may NOT submit regular Polkadot BH headers delivery transactions
+			assert_eq!(
+				BridgeHubPolkadotHeadersProvider::finalized_header_state_root(
+					bridge_hub_polkadot_header(HeaderType::WithMessages).hash()
+				),
+				None,
+			);
+			// can't use assert_noop here, because we need to mutate storage inside
+			// the `construct_and_apply_extrinsic`
+			assert_eq!(
+				submit_polkadot_bridge_hub_header(relayer_signer(), HeaderType::WithMessages),
+				Err(TransactionValidityError::Invalid(InvalidTransaction::BadSigner)),
+			);
+			assert_eq!(
+				BridgeHubPolkadotHeadersProvider::finalized_header_state_root(
+					bridge_hub_polkadot_header(HeaderType::WithMessages).hash()
+				),
+				None
+			);
+		})
+	}
+
+	#[test]
+	fn whitelisted_relayer_may_deliver_messages_from_polkadot_bridge_hub() {
+		run_test(|| {
+			WhitelistedRelayers::set(&vec![relayer_signer().into()]);
+			assert_ok_ok(initialize_polkadot_grandpa_pallet());
+			assert_ok_ok(submit_polkadot_header(relayer_signer(), HeaderType::WithMessages));
+			assert_ok_ok(submit_polkadot_bridge_hub_header(
+				relayer_signer(),
+				HeaderType::WithMessages,
+			));
+
+			// whitelisted relayer may deliver messages from Polkadot BH
+			assert!(BridgePolkadotMessages::inbound_lane_data(XCM_LANE).relayers.is_empty());
+			assert_ok_ok(submit_messages_from_polkadot_bridge_hub(relayer_signer()));
+			assert!(!BridgePolkadotMessages::inbound_lane_data(XCM_LANE).relayers.is_empty());
+		})
+	}
+
+	#[test]
+	fn non_relayer_may_not_deliver_messages_from_polkadot_bridge_hub() {
+		run_test(|| {
+			WhitelistedRelayers::set(&vec![relayer_signer().into()]);
+			assert_ok_ok(initialize_polkadot_grandpa_pallet());
+			assert_ok_ok(submit_polkadot_header(relayer_signer(), HeaderType::WithMessages));
+			assert_ok_ok(submit_polkadot_bridge_hub_header(
+				relayer_signer(),
+				HeaderType::WithMessages,
+			));
+
+			// non relayer may NOT deliver messages from Polkadot BH
+			assert!(BridgePolkadotMessages::inbound_lane_data(XCM_LANE).relayers.is_empty());
+			assert_eq!(
+				submit_messages_from_polkadot_bridge_hub(non_relay_signer()),
+				Err(TransactionValidityError::Invalid(InvalidTransaction::BadSigner)),
+			);
+			assert!(BridgePolkadotMessages::inbound_lane_data(XCM_LANE).relayers.is_empty());
+		})
+	}
+
+	#[test]
+	fn whitelisted_relayer_may_deliver_confirmations_from_polkadot_bridge_hub() {
+		run_test(|| {
+			WhitelistedRelayers::set(&vec![relayer_signer().into()]);
+			assert_ok_ok(initialize_polkadot_grandpa_pallet());
+			assert_ok_ok(submit_polkadot_header(
+				relayer_signer(),
+				HeaderType::WithDeliveredMessages,
+			));
+			assert_ok_ok(submit_polkadot_bridge_hub_header(
+				relayer_signer(),
+				HeaderType::WithDeliveredMessages,
+			));
+			emulate_sent_messages();
+
+			// whitelisted relayer may deliver messages from Polkadot BH
+			assert_eq!(
+				BridgePolkadotMessages::outbound_lane_data(XCM_LANE).latest_received_nonce,
+				0
+			);
+			assert_ok_ok(submit_confirmations_from_polkadot_bridge_hub(relayer_signer()));
+			assert_ne!(
+				BridgePolkadotMessages::outbound_lane_data(XCM_LANE).latest_received_nonce,
+				0
+			);
+		})
+	}
+
+	#[test]
+	fn non_relayer_may_not_deliver_confirmations_from_polkadot_bridge_hub() {
+		run_test(|| {
+			WhitelistedRelayers::set(&vec![relayer_signer().into()]);
+			assert_ok_ok(initialize_polkadot_grandpa_pallet());
+			assert_ok_ok(submit_polkadot_header(
+				relayer_signer(),
+				HeaderType::WithDeliveredMessages,
+			));
+			assert_ok_ok(submit_polkadot_bridge_hub_header(
+				relayer_signer(),
+				HeaderType::WithDeliveredMessages,
+			));
+			emulate_sent_messages();
+
+			// non relayer may NOT deliver messages from Polkadot BH
+			assert_eq!(
+				BridgePolkadotMessages::outbound_lane_data(XCM_LANE).latest_received_nonce,
+				0
+			);
+			assert_eq!(
+				submit_confirmations_from_polkadot_bridge_hub(non_relay_signer()),
+				Err(TransactionValidityError::Invalid(InvalidTransaction::BadSigner)),
+			);
+			assert_eq!(
+				BridgePolkadotMessages::outbound_lane_data(XCM_LANE).latest_received_nonce,
+				0
+			);
+		})
+	}
+
+	#[test]
+	fn ensure_lane_weights_are_correct() {
+		check_message_lane_weights::<
+			bp_polkadot_bulletin::PolkadotBulletin,
+			Runtime,
+			WithBridgeHubPolkadotMessagesInstance,
+		>(
+			bp_bridge_hub_polkadot::EXTRA_STORAGE_PROOF_SIZE,
+			bp_polkadot_bulletin::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
+			bp_polkadot_bulletin::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,
+			false,
+		);
+	}
+
+	#[test]
+	fn ensure_bridge_integrity() {
+		assert_complete_bridge_types!(
+			runtime: Runtime,
+			with_bridged_chain_grandpa_instance: WithPolkadotBridgeGrandpaInstance,
+			with_bridged_chain_messages_instance: WithBridgeHubPolkadotMessagesInstance,
+			bridge: WithBridgeHubPolkadotMessageBridge,
+			this_chain: bp_polkadot_bulletin::PolkadotBulletin,
+			bridged_chain: bp_polkadot::Polkadot,
+		);
+
+		assert_complete_bridge_constants::<
+			Runtime,
+			WithPolkadotBridgeGrandpaInstance,
+			WithBridgeHubPolkadotMessagesInstance,
+			WithBridgeHubPolkadotMessageBridge,
+		>(AssertCompleteBridgeConstants {
+			this_chain_constants: AssertChainConstants {
+				block_length: bp_polkadot_bulletin::BlockLength::get(),
+				block_weights: bp_polkadot_bulletin::BlockWeights::get(),
+			},
+			messages_pallet_constants: AssertBridgeMessagesPalletConstants {
+				max_unrewarded_relayers_in_bridged_confirmation_tx:
+					bp_bridge_hub_polkadot::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
+				max_unconfirmed_messages_in_bridged_confirmation_tx:
+					bp_bridge_hub_polkadot::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,
+				bridged_chain_id: bp_runtime::BRIDGE_HUB_POLKADOT_CHAIN_ID,
+			},
+			pallet_names: AssertBridgePalletNames {
+				with_this_chain_messages_pallet_name:
+					bp_polkadot_bulletin::WITH_POLKADOT_BULLETIN_MESSAGES_PALLET_NAME,
+				with_bridged_chain_grandpa_pallet_name:
+					bp_polkadot::WITH_POLKADOT_GRANDPA_PALLET_NAME,
+				with_bridged_chain_messages_pallet_name:
+					bp_bridge_hub_polkadot::WITH_BRIDGE_HUB_POLKADOT_MESSAGES_PALLET_NAME,
+			},
+		});
+	}
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -6,8 +6,12 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
+use bridge_runtime_common::generate_bridge_reject_obsolete_headers_and_messages;
 use frame_support::traits::ValidatorRegistration;
 use frame_system::EnsureRoot;
+use pallet_bridge_grandpa::Call as BridgeGrandpaCall;
+use pallet_bridge_messages::Call as BridgeMessagesCall;
+use pallet_bridge_parachains::Call as BridgeParachainsCall;
 use pallet_grandpa::AuthorityId as GrandpaId;
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use sp_api::impl_runtime_apis;
@@ -49,6 +53,8 @@ pub use pallet_timestamp::Call as TimestampCall;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
+
+mod bridge_config;
 
 /// An index to a block.
 pub type BlockNumber = u32;
@@ -377,6 +383,10 @@ construct_runtime!(
 		Grandpa: pallet_grandpa,
 		Sudo: pallet_sudo,
 		TransactionStorage: pallet_transaction_storage,
+		// Bridge pallets
+		BridgePolkadotGrandpa: pallet_bridge_grandpa,
+		BridgePolkadotParachains: pallet_bridge_parachains,
+		BridgePolkadotMessages: pallet_bridge_messages,
 	}
 );
 
@@ -453,6 +463,18 @@ impl SignedExtension for ValidateSigned {
 				ValidatorSet::pre_dispatch_set_keys(who),
 			Self::Call::Session(pallet_session::Call::<Runtime>::purge_keys {}) =>
 				validate_purge_keys(who).map(|_| ()),
+			Self::Call::BridgePolkadotGrandpa(BridgeGrandpaCall::submit_finality_proof {
+				..
+			}) |
+			Self::Call::BridgePolkadotParachains(
+				BridgeParachainsCall::submit_parachain_heads { .. },
+			) |
+			Self::Call::BridgePolkadotMessages(BridgeMessagesCall::receive_messages_proof {
+				..
+			}) |
+			Self::Call::BridgePolkadotMessages(
+				BridgeMessagesCall::receive_messages_delivery_proof { .. },
+			) => bridge_config::ensure_whitelisted_relayer(who).map(|_| ()),
 			_ => Err(InvalidTransaction::Call.into()),
 		}
 	}
@@ -475,9 +497,33 @@ impl SignedExtension for ValidateSigned {
 				}),
 			Self::Call::Session(pallet_session::Call::<Runtime>::purge_keys {}) =>
 				validate_purge_keys(who),
+			Self::Call::BridgePolkadotGrandpa(BridgeGrandpaCall::submit_finality_proof {
+				..
+			}) |
+			Self::Call::BridgePolkadotParachains(
+				BridgeParachainsCall::submit_parachain_heads { .. },
+			) |
+			Self::Call::BridgePolkadotMessages(BridgeMessagesCall::receive_messages_proof {
+				..
+			}) |
+			Self::Call::BridgePolkadotMessages(
+				BridgeMessagesCall::receive_messages_delivery_proof { .. },
+			) => bridge_config::ensure_whitelisted_relayer(who),
 			_ => Err(InvalidTransaction::Call.into()),
 		}
 	}
+}
+
+// it'll generate signed extensions to invalidate obsolete bridge transactions before
+// they'll be included into block
+generate_bridge_reject_obsolete_headers_and_messages! {
+	RuntimeCall, AccountId,
+	// Grandpa
+	BridgePolkadotGrandpa,
+	// Parachains
+	BridgePolkadotParachains,
+	// Messages
+	BridgePolkadotMessages
 }
 
 /// The SignedExtension to the basic transaction logic.
@@ -490,6 +536,7 @@ pub type SignedExtra = (
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	ValidateSigned,
+	BridgeRejectObsoleteHeadersAndMessages,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.


### PR DESCRIPTION
*The fully working bridge may be started by using branches, mentioned in https://github.com/paritytech/parity-bridges-common/issues/2547. I'm going to open multiple PRs to make it easier to review - some PRs need a different set of reviewers*

This PR adds pallets + basic (non-working because XCM is still missing - will open a draft PR for that soon) bridge configuration + tests. So far there's no way to send messages from Bulletin chain to Polkadot.BH and do an actual dispatch at Bulletin chain. Other than that, everything in Bulletin chain runtime is configured properly.

Don't bother much time on reviewing updates in `bridges` subtree - they have been reviewed in the bridges repo (normally we use a separate PR for that). [@paritytech/bridges-core](https://github.com/orgs/paritytech/teams/bridges-core) please review config too