### PR TITLE
Add basic XCM configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5570,6 +5570,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
+ "log",
  "pallet-authorship",
  "pallet-babe",
  "pallet-grandpa",
@@ -5596,6 +5597,9 @@ dependencies = [
  "sp-transaction-storage-proof",
  "sp-version",
  "substrate-wasm-builder",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -124,6 +124,9 @@ runtime-benchmarks = [
 
 	"pallet-transaction-storage/runtime-benchmarks",
 	"pallet-validator-set/runtime-benchmarks",
+
+	"xcm-builder/runtime-benchmarks",
+	"xcm-executor/runtime-benchmarks",
 ]
 try-runtime = [
 	"frame-executive/try-runtime",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,6 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+log = { version = "0.4", default-features = false }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 
 frame-executive = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
@@ -52,6 +53,11 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 pallet-transaction-storage = { version = "4.0.0-dev", default-features = false, path = "../pallets/transaction-storage" }
 pallet-validator-set = { version = "1.0.0", default-features = false, path = "../pallets/validator-set" }
 
+# XCM dependencies
+xcm = { git = "https://github.com/paritytech/polkadot.git", default-features = false, branch = "release-v1.0.0" }
+xcm-builder = { git = "https://github.com/paritytech/polkadot.git", default-features = false, branch = "release-v1.0.0" }
+xcm-executor = { git = "https://github.com/paritytech/polkadot.git", default-features = false, branch = "release-v1.0.0" }
+
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", optional = true, branch = "polkadot-v1.0.0" }
 
@@ -59,6 +65,7 @@ substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/pari
 default = ["std"]
 std = [
 	"codec/std",
+	"log/std",
 	"scale-info/std",
 
 	"frame-executive/std",
@@ -94,6 +101,10 @@ std = [
 
 	"pallet-transaction-storage/std",
 	"pallet-validator-set/std",
+
+	"xcm/std",
+	"xcm-builder/std",
+	"xcm-executor/std",
 
 	"substrate-wasm-builder",
 ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -50,6 +50,8 @@ pub use pallet_timestamp::Call as TimestampCall;
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
 
+mod xcm_config;
+
 /// An index to a block.
 pub type BlockNumber = u32;
 

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -43,7 +43,7 @@ parameter_types! {
 	/// Our location in the universe of consensus systems.
 	pub const UniversalLocation: InteriorMultiLocation = X1(GlobalConsensus(ThisNetwork::get()));
 
-	/// Location of the Kawabunga chain, relative to this runtime.
+	/// Location of the Kawabunga parachain, relative to this runtime.
 	pub KawabungaLocation: MultiLocation = MultiLocation::new(1, X2(
 		GlobalConsensus(Polkadot),
 		Parachain(KAWABUNGA_PARACHAIN_ID),

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -66,8 +66,6 @@ match_types! {
 	};
 }
 
-// TODO [PR]: what origin we are going to use to dispatch XCM calls over the bridge?
-// right now it is root (root of the Bulletin chain).
 /// Kawabunga location converter to local root.
 pub struct KawabungaParachainAsRoot;
 

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -85,10 +85,9 @@ impl ConvertOrigin<RuntimeOrigin> for KawabungaParachainAsRoot {
 				OriginKind::Superuser,
 				MultiLocation {
 					parents: 1,
-					interior: X2(GlobalConsensus(remote_network), Parachain(remote_parachain)),
+					interior: X2(GlobalConsensus(Polkadot), Parachain(KAWABUNGA_PARACHAIN_ID)),
 				},
-			) if remote_network == Polkadot && remote_parachain == KAWABUNGA_PARACHAIN_ID =>
-				Ok(RuntimeOrigin::root()),
+			) => Ok(RuntimeOrigin::root()),
 			(_, origin) => Err(origin),
 		}
 	}

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -248,7 +248,7 @@ mod tests {
 		// ensure that it passes local XCM Barrier
 		assert_eq!(
 			Barrier::should_execute(
-				&MultiLocation::new(1, bridge_hub_universal_location),
+				&Here.into(),
 				xcm.inner_mut(),
 				Weight::MAX,
 				&mut Properties { weight_credit: Weight::MAX, message_id: None },

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -113,7 +113,7 @@ impl WeightTrader for NoopTrader {
 /// Allows execution from `origin` if it is contained in `AllowedOrigin`
 /// and if it is just a straight `Transact` which contains `AllowedCall`.
 ///
-/// That's a 1:1 copy of corresponding Cumulus structire.
+/// That's a 1:1 copy of corresponding Cumulus structure.
 pub struct AllowUnpaidTransactsFrom<RuntimeCall, AllowedOrigin>(
 	sp_std::marker::PhantomData<(RuntimeCall, AllowedOrigin)>,
 );

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -34,11 +34,12 @@ use xcm_executor::{
 	Assets,
 };
 
+// TODO [bridge]: change to actual value here + everywhere where Kawabunga is mentioned
 /// Id of the Polkadot parachain that we are going to bridge with.
 const KAWABUNGA_PARACHAIN_ID: u32 = 42;
 
 parameter_types! {
-	// TODO [PR]: how we are supposed to set it? Named? ByGenesis - if so, when? After generating
+	// TODO [bridge]: how we are supposed to set it? Named? ByGenesis - if so, when? After generating
 	// chain spec?
 	/// The Polkadot Bulletin Chain network ID.
 	pub const ThisNetwork: NetworkId = NetworkId::ByGenesis([42u8; 32]);
@@ -196,7 +197,7 @@ impl xcm_executor::Config for XcmConfig {
 	type IsTeleporter = ();
 	type UniversalLocation = UniversalLocation;
 	type Barrier = Barrier;
-	// TODO [PR]: is it ok to use `FixedWeightBounds` here? We don't have the `pallet-xcm`
+	// TODO [bridge]: is it ok to use `FixedWeightBounds` here? We don't have the `pallet-xcm`
 	// and IIUC can't use XCM benchmarks because of that?
 	type Weigher = FixedWeightBounds<BaseXcmWeight, RuntimeCall, MaxInstructions>;
 	type Trader = NoopTrader;

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -128,7 +128,7 @@ impl<RuntimeCall: Decode, AllowedOrigin: Contains<MultiLocation>> ShouldExecute
 	) -> Result<(), ProcessMessageError> {
 		log::trace!(
 			target: "xcm::barriers",
-			"AllowUnpaidTransactFrom origin: {:?}, instructions: {:?}, max_weight: {:?}, properties: {:?}",
+			"AllowUnpaidTransactsFrom origin: {:?}, instructions: {:?}, max_weight: {:?}, properties: {:?}",
 			origin, instructions, max_weight, _properties,
 		);
 

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -1,0 +1,227 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! XCM configuration for Polkadot Bulletin chain.
+
+use crate::{AllPalletsWithSystem, RuntimeCall, RuntimeOrigin};
+
+use codec::Decode;
+use frame_support::{
+	ensure, match_types, parameter_types,
+	traits::{Contains, Nothing, ProcessMessageError},
+	weights::Weight,
+};
+use sp_core::ConstU32;
+use xcm::{latest::prelude::*, DoubleEncoded};
+use xcm_builder::{CreateMatcher, FixedWeightBounds, MatchXcm, TrailingSetTopicAsId};
+use xcm_executor::{
+	traits::{ConvertOrigin, ShouldExecute, WeightTrader, WithOriginFilter},
+	Assets,
+};
+
+/// Id of the Polkadot parachain that we are going to bridge with.
+const KAWABUNGA_PARACHAIN_ID: u32 = 42;
+
+parameter_types! {
+	// TODO [PR]: how we are supposed to set it? Named? ByGenesis - if so, when? After generating
+	// chain spec?
+	/// The Polkadot Bulletin Chain network ID.
+	pub const ThisNetwork: NetworkId = NetworkId::ByGenesis([42u8; 32]);
+	/// Our location in the universe of consensus systems.
+	pub const UniversalLocation: InteriorMultiLocation = X1(GlobalConsensus(ThisNetwork::get()));
+
+	/// Location of the Kawabunga chain, relative to this runtime.
+	pub KawabungaLocation: MultiLocation = MultiLocation::new(1, X2(
+		GlobalConsensus(Polkadot),
+		Parachain(KAWABUNGA_PARACHAIN_ID),
+	));
+
+	/// The amount of weight an XCM operation takes. This is a safe overestimate.
+	pub const BaseXcmWeight: Weight = Weight::from_parts(1_000_000_000, 0);
+	/// Maximum number of instructions in a single XCM fragment. A sanity check against weight
+	/// calculations getting too crazy.
+	pub const MaxInstructions: u32 = 100;
+}
+
+match_types! {
+	// Only contains Kawabunga parachain location.
+	pub type OnlyKawabungaLocation: impl Contains<MultiLocation> = {
+		MultiLocation { parents: 1, interior: X2(
+			GlobalConsensus(Polkadot),
+			Parachain(KAWABUNGA_PARACHAIN_ID),
+		) }
+	};
+
+	// Only passes calls that may be called using XCM transact through the bridge.
+	pub type AllowedXcmTransactCalls: impl Contains<RuntimeCall> = {
+		// TODO [PR or later]: we need to add all supported over-XCM calls here.
+		// what is the set?
+		_
+	};
+}
+
+// TODO [PR]: what origin we are going to use to dispatch XCM calls over the bridge?
+// right now it is root (root of the Bulletin chain).
+/// Kawabunga location converter to local root.
+pub struct KawabungaParachainAsRoot;
+
+impl ConvertOrigin<RuntimeOrigin> for KawabungaParachainAsRoot {
+	fn convert_origin(
+		origin: impl Into<MultiLocation>,
+		kind: OriginKind,
+	) -> Result<RuntimeOrigin, MultiLocation> {
+		let origin = origin.into();
+		log::trace!(
+			target: "xcm::origin_conversion",
+			"KawabungaParachainAsRoot origin: {:?}, kind: {:?}",
+			origin, kind,
+		);
+		match (kind, origin) {
+			(
+				OriginKind::Superuser,
+				MultiLocation {
+					parents: 1,
+					interior: X2(GlobalConsensus(remote_network), Parachain(remote_parachain)),
+				},
+			) if remote_network == Polkadot && remote_parachain == KAWABUNGA_PARACHAIN_ID =>
+				Ok(RuntimeOrigin::root()),
+			(_, origin) => Err(origin),
+		}
+	}
+}
+
+/// Weight trader that does nothing.
+pub struct NoopTrader;
+
+impl WeightTrader for NoopTrader {
+	fn new() -> Self {
+		NoopTrader
+	}
+
+	fn buy_weight(&mut self, _weight: Weight, _payment: Assets) -> Result<Assets, XcmError> {
+		Ok(Assets::new())
+	}
+
+	fn refund_weight(&mut self, _weight: Weight) -> Option<MultiAsset> {
+		None
+	}
+}
+
+/// Allows execution from `origin` if it is contained in `AllowedOrigin`
+/// and if it is just a straight `Transact` which contains `AllowedCall`.
+///
+/// That's a 1:1 copy of corresponding Cumulus structire.
+pub struct AllowUnpaidTransactsFrom<RuntimeCall, AllowedCall, AllowedOrigin>(
+	sp_std::marker::PhantomData<(RuntimeCall, AllowedCall, AllowedOrigin)>,
+);
+impl<
+		RuntimeCall: Decode,
+		AllowedCall: Contains<RuntimeCall>,
+		AllowedOrigin: Contains<MultiLocation>,
+	> ShouldExecute for AllowUnpaidTransactsFrom<RuntimeCall, AllowedCall, AllowedOrigin>
+{
+	fn should_execute<Call>(
+		origin: &MultiLocation,
+		instructions: &mut [Instruction<Call>],
+		max_weight: Weight,
+		_properties: &mut xcm_executor::traits::Properties,
+	) -> Result<(), ProcessMessageError> {
+		log::trace!(
+			target: "xcm::barriers",
+			"AllowUnpaidTransactFrom origin: {:?}, instructions: {:?}, max_weight: {:?}, properties: {:?}",
+			origin, instructions, max_weight, _properties,
+		);
+
+		// we only allow from configured origins
+		ensure!(AllowedOrigin::contains(origin), ProcessMessageError::Unsupported);
+
+		// we expect an XCM program with single `Transact` call
+		instructions
+			.matcher()
+			.assert_remaining_insts(1)?
+			.match_next_inst(|inst| match inst {
+				Transact { origin_kind: OriginKind::Superuser, call: encoded_call, .. } => {
+					// this is a hack - don't know if there's a way to do that properly
+					// or else we can simply allow all calls
+					let mut decoded_call = DoubleEncoded::<RuntimeCall>::from(encoded_call.clone());
+					ensure!(
+						AllowedCall::contains(
+							decoded_call
+								.ensure_decoded()
+								.map_err(|_| ProcessMessageError::BadFormat)?
+						),
+						ProcessMessageError::BadFormat,
+					);
+
+					Ok(())
+				},
+				_ => Err(ProcessMessageError::BadFormat),
+			})?;
+
+		Ok(())
+	}
+}
+
+/// The means that we convert an XCM origin `MultiLocation` into the runtime's `Origin` type for
+/// local dispatch. This is a conversion function from an `OriginKind` type along with the
+/// `MultiLocation` value and returns an `Origin` value or an error.
+type LocalOriginConverter = (
+	// Currently we only accept XCM messages from Kawabunga and the origin for such messages
+	// is local root.
+	KawabungaParachainAsRoot,
+);
+
+// TODO [bridge]: configure to use bridge blob hauler here
+/// Only bridged destination is supported.
+pub type XcmRouter = ();
+
+/// The barriers one of which must be passed for an XCM message to be executed.
+pub type Barrier = TrailingSetTopicAsId<
+	// We only allow unpaid execution from the Kawabunga parachain.
+	AllowUnpaidTransactsFrom<RuntimeCall, AllowedXcmTransactCalls, OnlyKawabungaLocation>,
+>;
+
+/// XCM executor configuration.
+pub struct XcmConfig;
+
+impl xcm_executor::Config for XcmConfig {
+	type RuntimeCall = RuntimeCall;
+	type XcmSender = XcmRouter;
+	type AssetTransactor = ();
+	type OriginConverter = LocalOriginConverter;
+	type IsReserve = ();
+	type IsTeleporter = ();
+	type UniversalLocation = UniversalLocation;
+	type Barrier = Barrier;
+	// TODO [PR]: is it ok to use `FixedWeightBounds` here? We don't have the `pallet-xcm`
+	// and IIUC can't use XCM benchmarks because of that?
+	type Weigher = FixedWeightBounds<BaseXcmWeight, RuntimeCall, MaxInstructions>;
+	type Trader = NoopTrader;
+	type ResponseHandler = ();
+	type AssetTrap = ();
+	type AssetLocker = ();
+	type AssetExchanger = ();
+	type AssetClaims = ();
+	type SubscriptionService = ();
+	type PalletInstancesInfo = AllPalletsWithSystem;
+	type MaxAssetsIntoHolding = ConstU32<0>;
+	type FeeManager = ();
+	type MessageExporter = ();
+	type UniversalAliases = Nothing;
+	type CallDispatcher = WithOriginFilter<AllowedXcmTransactCalls>;
+	type SafeCallFilter = AllowedXcmTransactCalls;
+	type Aliasers = Nothing;
+}

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -211,7 +211,7 @@ impl xcm_executor::Config for XcmConfig {
 	type MaxAssetsIntoHolding = ConstU32<0>;
 	type FeeManager = ();
 	type MessageExporter = ();
-	type UniversalAliases = Nothing;
+	type UniversalAliases = UniversalAliases;
 	type CallDispatcher = WithOriginFilter<Everything>;
 	type SafeCallFilter = Everything;
 	type Aliasers = Nothing;


### PR DESCRIPTION
*The fully working bridge may be started by using branches, mentioned in https://github.com/paritytech/parity-bridges-common/issues/2547. I'm going to open multiple PRs to make it easier to review - some PRs need a different set of reviewers*

From bridges perspective, we need an XCM configuration to be able to dispatch inbound messages. I'm not pretending to be an XCM expert, so I'm opening this PR to ask questions and collectively understand what we need. This PR doesn't do anything with bridge - it just adds the `xcm_executor::Config`, required to be able to execute XCM programs.

Some important points:
- I haven't added the `pallet-xcm` to runtime, because IIUC we don't need it here. However if you think we need it, we may try to plug it in;
- I've mentioned `Kawabunga` parachain - it is the parachain, which will be bridging with the Bulletin chain over Polkadot BH, which is not available;
- I'll leave explicit PR comments where I need some help and/or we may need to discuss something.

Also pinging https://github.com/orgs/paritytech/teams/bridges-core for review